### PR TITLE
Remove default "/bot" alias when botalias plugin is loaded

### DIFF
--- a/hangupsbot/plugins/botaliases.py
+++ b/hangupsbot/plugins/botaliases.py
@@ -10,7 +10,7 @@ def _initialise(Handlers, bot=None):
     else:
         myself = bot.user_self()
         # basic
-        bot_command_aliases = ["/bot"]
+        bot_command_aliases = []
         # /<first name fragment>
         first_fragment = myself["full_name"].split()[0].lower()
         if first_fragment and first_fragment != "unknown":


### PR DESCRIPTION
Remove "/bot" to prevent bot wars.