### PR TITLE
[plugin] default: convid-commands

### DIFF
--- a/hangupsbot/handlers.py
+++ b/hangupsbot/handlers.py
@@ -101,7 +101,12 @@ class EventHandler:
 
         # Parse message
         event.text = event.text.replace(u'\xa0', u' ') # convert non-breaking space in Latin1 (ISO 8859-1)
-        line_args = shlex.split(event.text, posix=False)
+        try:
+            line_args = shlex.split(event.text, posix=False)
+        except Exception as e:
+            print("EXCEPTION in {}: {}".format("handle_command", e))
+            logging.exception(e)
+            return
 
         # Test if command length is sufficient
         if len(line_args) < 2:

--- a/hangupsbot/plugins/default.py
+++ b/hangupsbot/plugins/default.py
@@ -21,25 +21,27 @@ def _initialise(bot):
 def get_posix_args(rawargs):
     lexer = shlex.shlex(" ".join(rawargs), posix=True)
     lexer.commenters = ""
-    lexer.wordchars += "!@#$%^&*():/.<>?[]-"
+    lexer.wordchars += "!@#$%^&*():/.<>?[]-,"
     posix_args = list(lexer)
     return posix_args
 
 
 def convfilter(bot, event, *args):
-    """display raw list of conversations returned by filter"""
-    fragment = ' '.join(args)
+    """test filter and return matched conversations"""
+    posix_args = get_posix_args(args)
 
-    if fragment.startswith('"') and fragment.endswith('"'):
-        # strip away double-quotes if supplied
-        fragment = fragment[1:-1]
-
-    lines = []
-    for convid, convdata in get_all_conversations(filter=fragment).items():
-        lines.append("`{}` <b>{}</b> ({})".format(convid, convdata["title"], len(convdata["users"])))
-    lines.append(_('<b>Total: {}</b>').format(len(lines)))
-
-    bot.send_message_parsed(event.conv_id, '<br />'.join(lines))
+    if len(posix_args) > 1:
+        bot.send_message_parsed(event.conv_id, 
+            _("<em>1 parameter required, {} supplied - enclose parameter in double-quotes</em>").format(len(posix_args)))
+    elif len(posix_args) <= 0:
+        bot.send_message_parsed(event.conv_id, 
+            _("<em>supply 1 parameter</em>"))
+    else:
+        lines = []
+        for convid, convdata in get_all_conversations(filter=posix_args[0]).items():
+            lines.append("`{}` <b>{}</b> ({})".format(convid, convdata["title"], len(convdata["users"])))
+        lines.append(_('<b>Total: {}</b>').format(len(lines)))
+        bot.send_message_parsed(event.conv_id, '<br />'.join(lines))
 
 
 def convecho(bot, event, *args):

--- a/hangupsbot/plugins/default.py
+++ b/hangupsbot/plugins/default.py
@@ -113,8 +113,9 @@ def convusers(bot, event, *args):
         """don't do it in all conversations - might crash hangups"""
         text = _("<em>retrieving ALL conversations blocked</em>")
     else:
-        lines = []
+        chunks = [] # one "chunk" = info for 1 hangout
         for convid, convdata in get_all_conversations(filter=posix_args[0]).items():
+            lines = []
             lines.append('<b>{}</b>'.format(convdata["title"], len(convdata["users"])))
             for user in convdata["users"]:
                 # name and G+ link
@@ -130,7 +131,8 @@ def convusers(bot, event, *args):
                 _line += "<br />... {}".format(user[0][0]) # user id
                 lines.append(_line)
             lines.append(_('<b>Users: {}</b>').format(len(convdata["users"])))
-        text = '<br />'.join(lines)
+            chunks.append('<br />'.join(lines))
+        text = '<br /><br />'.join(chunks) 
 
     bot.send_message_parsed(event.conv_id, text)
 

--- a/hangupsbot/plugins/default.py
+++ b/hangupsbot/plugins/default.py
@@ -30,6 +30,10 @@ def convfilter(bot, event, *args):
     """display raw list of conversations returned by filter"""
     fragment = ' '.join(args)
 
+    if fragment.startswith('"') and fragment.endswith('"'):
+        # strip away double-quotes if supplied
+        fragment = fragment[1:-1]
+
     lines = []
     for convid, convdata in get_all_conversations(filter=fragment).items():
         lines.append("`{}` <b>{}</b> ({})".format(convid, convdata["title"], len(convdata["users"])))

--- a/hangupsbot/plugins/default.py
+++ b/hangupsbot/plugins/default.py
@@ -1,4 +1,4 @@
-import json
+import json, shlex
 
 import hangups
 
@@ -12,39 +12,42 @@ _internal = {} # non-persistent internal state independent of config.json/memory
 _internal["broadcast"] = { "message": "", "conversations": [] } # /bot broadcast
 
 def _initialise(bot):
-    plugins.register_admin_command(["broadcast", "convfilter", "users", "user", "hangouts", "rename", "leave", "reload", "quit", "config", "whereami"])
+    plugins.register_admin_command(["broadcast", "convecho", "convfilter", "users", "user", "hangouts", "rename", "leave", "reload", "quit", "config", "whereami"])
     plugins.register_user_command(["echo", "echoparsed", "whoami"])
-
-def _filter_convlist(bot, fragment):
-    # get definitive list of all conversations
-    convs = get_all_conversations()
-
-    filtered = [] # function always return tuple(convid, convdata)
-
-    if fragment in convs:
-        # prioritise exact convid matches
-        filtered.append((fragment, convs[fragment]))
-    else:
-        # perform case-insensitive search
-        fragment_lower = fragment.lower()
-        for convid, convdata in convs.items():
-            if fragment_lower in convdata["title"].lower():
-                filtered.append((convid, convdata))
-
-    return filtered
 
 
 def convfilter(bot, event, *args):
     fragment = ' '.join(args)
 
-    convlist = _filter_convlist(bot, fragment)
-
     lines = []
-    for convid, convdata in convlist:
+    for convid, convdata in get_all_conversations(filter=fragment, inexact=True).items():
         lines.append("{} <b>{}</b>".format(convid, convdata["title"], len(convdata["users"])))
     lines.append("Total: {}".format(len(lines)))
 
     bot.send_message_parsed(event.conv_id, '<br />'.join(lines))
+
+
+def convecho(bot, event, *args):
+    lexer = shlex.shlex(" ".join(args), posix=True)
+    lexer.wordchars += ":/"
+    posix_args = list(lexer)
+
+    if(len(posix_args) > 1):
+        convlist = get_all_conversations(filter=posix_args[0])
+        text = ' '.join(posix_args[1:])
+        if text.lower().strip().startswith(tuple([cmd.lower() for cmd in bot._handlers.bot_command])):
+            text = _("command echo blocked")
+            convlist = get_all_conversations(filter=event.conv_id)
+    else:
+        text = _("required parameters: convfilter text")
+        convlist = get_all_conversations(filter=event.conv_id)
+
+    if not convlist:
+        text = _("no conversations filtered")
+        convlist = get_all_conversations(filter=event.conv_id)
+
+    for convid, convdata in convlist.items():
+        print("convecho: {} {}".format(convid, text))
 
 
 def echo(bot, event, *args):

--- a/hangupsbot/plugins/default.py
+++ b/hangupsbot/plugins/default.py
@@ -21,7 +21,7 @@ def _initialise(bot):
 def get_posix_args(rawargs):
     lexer = shlex.shlex(" ".join(rawargs), posix=True)
     lexer.commenters = ""
-    lexer.wordchars += "!@#$%^&*():/.<>?[]"
+    lexer.wordchars += "!@#$%^&*():/.<>?[]-"
     posix_args = list(lexer)
     return posix_args
 
@@ -32,7 +32,7 @@ def convfilter(bot, event, *args):
 
     lines = []
     for convid, convdata in get_all_conversations(filter=fragment).items():
-        lines.append("{} <b>{}</b>".format(convid, convdata["title"], len(convdata["users"])))
+        lines.append("`{}` <b>{}</b> ({})".format(convid, convdata["title"], len(convdata["users"])))
     lines.append(_('<b>Total: {}</b>').format(len(lines)))
 
     bot.send_message_parsed(event.conv_id, '<br />'.join(lines))
@@ -220,9 +220,9 @@ def hangouts(bot, event, *args):
 
     lines = []
     for convid, convdata in get_all_conversations(filter="text:" + text_search).items():
-        lines.append("<b>{}</b>: <em>{}</em>".format(convdata["title"], convid))
+        lines.append("<b>{}</b>: <em>`{}`</em>".format(convdata["title"], convid))
 
-    lines.append(_('<b>Total: {}</b>').format(len(lines)-1))
+    lines.append(_('<b>Total: {}</b>').format(len(lines)))
     if text_search:
         lines.insert(0, _('<b>List of hangouts with keyword:</b> "{}"').format(text_search))
 

--- a/hangupsbot/utils.py
+++ b/hangupsbot/utils.py
@@ -67,6 +67,22 @@ def get_conv_name(conv, truncate=False):
     return title
 
 
-def get_all_conversations():
-    return _conversation_list_cache
+def get_all_conversations(filter=False, inexact=True):
+    filtered = {} # function always return subset of conversation list
 
+    if not filter:
+        # return everything
+        filtered = _conversation_list_cache
+    elif filter in _conversation_list_cache:
+        # prioritise exact convid matches
+        filtered[filter] = _conversation_list_cache[filter]
+    elif inexact:
+        # perform inexact matching, special flags still required - don't guess user intent!
+        if filter.startswith("text:"):
+            # perform case-insensitive search
+            filter_lower = filter[5:].lower()
+            for convid, convdata in _conversation_list_cache.items():
+                if filter_lower in convdata["title"].lower():
+                    filtered[convid] = convdata
+
+    return filtered

--- a/hangupsbot/utils.py
+++ b/hangupsbot/utils.py
@@ -67,22 +67,24 @@ def get_conv_name(conv, truncate=False):
     return title
 
 
-def get_all_conversations(filter=False, inexact=True):
+def get_all_conversations(filter=False):
     filtered = {} # function always return subset of conversation list
 
     if not filter:
         # return everything
         filtered = _conversation_list_cache
+    elif filter.startswith("id:"):
+        # explicit request for single conv
+        convid = filter[3:]
+        filtered[convid] = _conversation_list_cache[convid]
     elif filter in _conversation_list_cache:
         # prioritise exact convid matches
         filtered[filter] = _conversation_list_cache[filter]
-    elif inexact:
-        # perform inexact matching, special flags still required - don't guess user intent!
-        if filter.startswith("text:"):
-            # perform case-insensitive search
-            filter_lower = filter[5:].lower()
-            for convid, convdata in _conversation_list_cache.items():
-                if filter_lower in convdata["title"].lower():
-                    filtered[convid] = convdata
+    elif filter.startswith("text:"):
+        # perform case-insensitive search
+        filter_lower = filter[5:].lower()
+        for convid, convdata in _conversation_list_cache.items():
+            if filter_lower in convdata["title"].lower():
+                filtered[convid] = convdata
 
     return filtered


### PR DESCRIPTION
Notes: All *convid-mandatory* commands supports posix-like arguments parsing 
  with [shlex](https://docs.python.org/3/library/shlex.html). 

This allows space-containing strings to be parameterised correctly with 
  the use of double-quotes; and special chars to be escaped with 
  backslashes e.g. `/bot convecho "text:\"hello" "hi there!"`

This branch requires the **convmem** plugin (at least until #218 is implemented)

The revamped default plugin is no longer backward-compatible with bot versions < 2.4

`/bot convfilter <search term>`

* works like bash `pgrep` for `pkill` - *use this command to test your convfilter search
  terms before using it for other conv-commands*
* lists filtered conversation by id, title and number of users
* `<search term>` can be:
  * `id:<convid>` or `<convid>` - returns single matching conversation
  * `text:<text fragment>` - return multiple conversations with matching fragment in title
  * `""` - returns all conversations (no filter)
* enclose `<search term>` with double-quotes if it contains spaces, and/or 
  special characters
* implemented in `utils.get_all_conversations(filter=False)` - a replacement function 
  for all instances where **convmem** or legacy `bot.list_conversations()` is required

`/bot convecho <convfilter: search term> <text>`

* echo back `<text>` into filterered conversation(s)
* can be used for bulk echos depending on `<convfilter: search term>` - 
  use `/bot convfilter` to identify targeted conversations
* to avoid spam, `""` as a `<convfilter: search term>` is blocked 
* both parameters can be optionally enclosed by double-quotes - 
  highly recommended if they contain spaces, and/or special characters
* html and markdown supported in `<text>`
* `/bot echo` and `/bot echoparsed` remapped to this command internally
  * note: `/bot echoparsed` obsoleted

`/bot convrename <convfilter: search term> <title>`

* renames a single matched conversation
* if `<convfilter: search term>` matches multiple conversations, only the first one will be 
   renamed - therefore, it is not recommended to use "fuzzy" search terms
* both parameters can be optionally enclosed by double-quotes - 
  highly recommended if they contain spaces, and/or special characters
* `/bot rename` remapped to this command internally

`/bot convusers <convfilter: search term>`

* displays the user list for matched conversations
* user list contains user chat id and user name
* to avoid generating excessively large messages, `""` as a `<convfilter: search term>` is blocked
* `<convfilter: search term>` can be optionally enclosed by double-quotes - 
  highly recommended if it contains spaces, and/or special characters
* `/bot users` remapped to this command internally

`/bot convleave <convfilter: search term> [quietly]`

* leaves the matched conversations
* append `quietly` flag so the bot doesn't announce anything before leaving
* to avoid accidentally leaving ALL conversations, `""` as a `<convfilter: search term>` is blocked
* `<convfilter: search term>` can be optionally enclosed by double-quotes - 
  highly recommended if it contains spaces, and/or special characters
* `/bot leave` remapped to this command internally

