### PR TITLE
nylonee/config cleanup

### DIFF
--- a/hangupsbot/config.json
+++ b/hangupsbot/config.json
@@ -13,18 +13,7 @@
     ]
   ],
   "cleverbot_percentage_replies": "0",
-  "commands_admin": [
-    "rename",
-    "leave",
-    "easteregg",
-    "user",
-    "users",
-    "hangouts",
-    "reload",
-    "quit",
-    "config",
-    "topic"
-  ],
+  "commands_admin": [],
   "commands_enabled": true,
   "conversations": {
     "CONV2_ID": {

--- a/hangupsbot/config.json
+++ b/hangupsbot/config.json
@@ -69,15 +69,6 @@
       "port": 8002
     }
   ],
-  "hooks": [
-    {
-      "module": "hooks.chatlogger.writer.logger",
-      "config":
-      {
-        "storage_path": false
-      }
-    }
-  ],
   "mentionerrors": true,
   "mentionall":true,
   "mentionallwhitelist": [],

--- a/hangupsbot/config.json
+++ b/hangupsbot/config.json
@@ -18,7 +18,7 @@
   "conversations": {
     "CONV2_ID": {
       "autoreplies_enabled": false,
-      "commands_enabled": false,
+      "commands_enabled": false
     }
   },
   "jsonrpc": [
@@ -27,7 +27,7 @@
       "certfile": null,
       "name": "127.0.0.1",
       "port": 9001
-    },
+    }
   ],
   "link_to_guide": "https://github.com/hangoutsbot/hangoutsbot/wiki/User-Guide",
   "mentionall":true,

--- a/hangupsbot/config.json
+++ b/hangupsbot/config.json
@@ -1,6 +1,7 @@
 {
   "admins": [
   ],
+  "autocreate-1to1": true,
   "autoreplies": [
     [
       [
@@ -10,6 +11,7 @@
       "Hello world!"
     ]
   ],
+  "cleverbot_percentage_replies": "0",
   "commands_admin": [
     "rename",
     "leave",
@@ -22,21 +24,14 @@
     "config",
     "topic"
   ],
-  "spreadsheet_enabled": false,
-  "spreadsheet_url": "INSERT_PUBLIC_URL_OF_GSHEET_HERE",
-  "syncing_enabled": false,
-  "sync_rooms": [["CONV1_ID", "CONV2_ID"],[]],
   "commands_enabled": true,
   "conversations": {
     "CONV2_ID": {
       "autoreplies_enabled": false,
       "commands_enabled": false,
-      "mentionall": false,
-      "mentionallwhitelist": []
     }
   },
-  "pushbullet": {
-  },
+  "donotdisturb": [],
   "jsonrpc": [
     {
       "module": "sinks.generic.simpledemo.webhookReceiver",
@@ -45,13 +40,13 @@
       "port": 9001
     },
   ],
-  "mentionerrors": true,
+  "link_to_guide": "https://github.com/hangoutsbot/hangoutsbot/wiki/User-Guide",
   "mentionall":true,
   "mentionallwhitelist": [],
+  "mentionerrors": true,
   "mentionquidproquo": false,
-  "donotdisturb": [],
   "plugins": null,
-  "strict_botkeeper_check": false,
+  "pushbullet": {},
   "slack": [
     {
     "certfile": null,
@@ -62,7 +57,10 @@
     "synced_conversations": ["CONV_ID1", "CONV_ID2"]
     }
   ],
-  "cleverbot_percentage_replies": "0",
-  "watch_new_adds": false,
-  "link_to_guide": "https://github.com/hangoutsbot/hangoutsbot/wiki/User-Guide"
+  "spreadsheet_enabled": false,
+  "spreadsheet_url": "INSERT_PUBLIC_URL_OF_GSHEET_HERE",
+  "strict_botkeeper_check": false,
+  "sync_rooms": [["CONV1_ID", "CONV2_ID"],[]],
+  "syncing_enabled": false,
+  "watch_new_adds": false
 }

--- a/hangupsbot/config.json
+++ b/hangupsbot/config.json
@@ -21,7 +21,6 @@
       "commands_enabled": false,
     }
   },
-  "donotdisturb": [],
   "jsonrpc": [
     {
       "module": "sinks.generic.simpledemo.webhookReceiver",

--- a/hangupsbot/config.json
+++ b/hangupsbot/config.json
@@ -44,30 +44,6 @@
       "name": "127.0.0.1",
       "port": 9001
     },
-    {
-      "module": "sinks.gitlab.simplepush.webhookReceiver",
-      "certfile": null,
-      "name": "",
-      "port": 8000
-    },
-    {
-      "module": "sinks.github.simplepush.webhookReceiver",
-      "certfile": null,
-      "name": "",
-      "port": 8001
-    },
-    {
-      "certfile": null,
-      "module": "sinks.hubotreceive.post.receiver",
-      "name": "127.0.0.1",
-      "port": 8081
-    },
-    {
-      "certfile": null,
-      "module": "sinks.google.scripts.webhookReceiver",
-      "name": "127.0.0.1",
-      "port": 8002
-    }
   ],
   "mentionerrors": true,
   "mentionall":true,

--- a/hangupsbot/config.json
+++ b/hangupsbot/config.json
@@ -2,6 +2,7 @@
   "admins": [
   ],
   "autocreate-1to1": true,
+  "autoreplies_enabled": true,
   "autoreplies": [
     [
       [

--- a/hangupsbot/config.json
+++ b/hangupsbot/config.json
@@ -36,7 +36,6 @@
   "mentionerrors": true,
   "mentionquidproquo": false,
   "plugins": null,
-  "pushbullet": {},
   "slack": [
     {
     "certfile": null,

--- a/hangupsbot/config.json
+++ b/hangupsbot/config.json
@@ -13,7 +13,7 @@
     ]
   ],
   "cleverbot_percentage_replies": "0",
-  "commands_admin": [],
+  "commands_user": [],
   "commands_enabled": true,
   "conversations": {
     "CONV2_ID": {


### PR DESCRIPTION
The config.json needed a bit of a cleanup, and some extra functions added.
* Hook config was removed (plugins are the new hooks!)
* All sink configs except one was removed as a sample
* Reorganized config.json alphabetically
* Removed the admin white-list commands (They are all already set as admin commands within the plugins). `commands_admin` replaced with `commands_user` (#182)
* Added autoreplies config (They will now be on by default. They're a popular feature)
* Removed legacy pushbullet and donotdisturb config (migration tool is sending them to memory.json upon first initialization)