### PR TITLE
2.5 Patch 2

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -52,6 +52,12 @@ To quit the bot from the console, press CTRL-C
 
 # Initial Configuration
 
+DO NOT EDIT the `config.json` supplied with the bot. It is the 
+  reference file used to generate the actual config file, which
+  is located elsewhere. Please see the next section on 
+  **Additional Configuration** to get the location of the 
+  actual configuration file if you need to edit it manually.
+
 You will need to add your actual Hangouts user as a bot administrator.
 
 This will be accomplished using the supplied **starter** plugin with

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Please see:
 
 # Running The Bot
 
-Note: First-time run? Please see the [installation instructions]
+Note: **First run?** See the [installation instructions]
   (https://github.com/hangoutsbot/hangoutsbot/blob/master/INSTALL.md)
 
 To execute: `python3 hangupsbot.py`

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 Hangupsbot is a chat bot designed for working with Google Hangouts.
 
 Please see:
-* [Instructions for installing](https://github.com/nylonee/hangupsbot/blob/master/INSTALL.md)
-* [Issue tracker](https://github.com/nylonee/hangupsbot/issues) for bugs, issues and feature requests
-* [Wiki](https://github.com/nylonee/hangupsbot/wiki) for everything else
+* [Instructions for installing](https://github.com/hangoutsbot/hangoutsbot/blob/master/INSTALL.md)
+* [Issue tracker](https://github.com/hangoutsbot/hangoutsbot/issues) for bugs, issues and feature requests
+* [Wiki](https://github.com/hangoutsbot/hangoutsbot/wiki) for everything else
 
 
 ## Repository Links
@@ -36,9 +36,13 @@ Please see:
   games, nickname support, subscribed keywords, customizable API - **[the list goes on]
     (https://github.com/nylonee/hangupsbot/wiki/Plugin-List)**!
 
-# IMPORTANT
+# Running The Bot
 
-* To execute: `python3 hangupsbot.py`
+Note: First-time run? Please see the [installation instructions]
+  (https://github.com/hangoutsbot/hangoutsbot/blob/master/INSTALL.md)
+
+To execute: `python3 hangupsbot.py`
+
 ```
 usage: hangupsbot [-h] [-d] [--log LOG] [--cookies COOKIES] [--memory MEMORY] [--config CONFIG] [--version]
 
@@ -55,9 +59,19 @@ optional arguments:
                    ~/.local/share/hangupsbot/config.json)
 --version          show program's version number and exit
 ```
+
 # Bot Configuration for Administrators
 
 Configuration directives can be specified in `config.json`.
+
+Please note that the `config.json` file supplied with the repository is not 
+  supposed to be edited/changed. It is the reference file used by the bot to 
+  create the actual configuration file located elsewhere in the system. To find out 
+  where the actual file is, please see the [**Additional Configuration** section]
+  (https://github.com/hangoutsbot/hangoutsbot/blob/master/INSTALL.md#additional-configuration)
+  in the [installation]
+  (https://github.com/hangoutsbot/hangoutsbot/blob/master/INSTALL.md)
+  instructions.
 
 Most configuration directives are specified **globally**
 * Global directives are always specified in the "root" of `config.json`.

--- a/hangupsbot/hangupsbot.py
+++ b/hangupsbot/hangupsbot.py
@@ -306,13 +306,20 @@ class HangupsBot(object):
         """
         if isinstance(conv_ids, str):
             conv_ids = [conv_ids]
-        all_users = []
         conv_ids = list(set(conv_ids))
-        for conversation in self.list_conversations():
-            for room_id in conv_ids:
-                if room_id in conversation.id_:
-                    all_users += conversation.users
-        all_users = list(set(all_users))
+
+        all_users = {}
+        for convid in conv_ids:
+            conv_data = self.conversations.catalog[convid]
+            for user in conv_data["users"]:
+                UserID = hangups.user.UserID(chat_id=user[0][0], gaia_id=user[0][1])
+                try:
+                    hangups_user = self._user_list._user_dict[UserID]
+                except KeyError as e:
+                    hangups_user = hangups.user.User(UserID, user[1], None, None, [], False)
+                all_users[UserID] = hangups_user
+        all_users = all_users.values()
+
         return all_users
 
     def get_config_option(self, option):

--- a/hangupsbot/plugins/convtools_invitations.py
+++ b/hangupsbot/plugins/convtools_invitations.py
@@ -345,6 +345,7 @@ def invite(bot, event, *args):
             if uid not in [u[0][0] for u in targetconv_users]:
                 invited_users.append(uid)
             else:
+                invitation_log.append("excluding existing: {}".format(uid))
                 logging.info("convtools_invitations: rejecting {}, already in {}".format(uid, targetconv))
         invited_users = list(set(invited_users))
 

--- a/hangupsbot/plugins/mentions.py
+++ b/hangupsbot/plugins/mentions.py
@@ -436,12 +436,12 @@ def setnickname(bot, event, *args):
     if event.user.id_.chat_id in nicks:
         if nickname.lower() == nicks[event.user.id_.chat_id].lower():
             actual_nickname = bot.memory.get_suboption("user_data", event.user.id_.chat_id, "nickname")
-            bot.send_message_parsed(event.conv, _('<i>Your nickname is already "') + actual_nickname + '".</i>')
+            bot.send_message_parsed(event.conv, _('<i>Your nickname is already <b>`{}`</b></i>').format(actual_nickname))
             return
 
     # check whether another user has the same nickname
     if nickname.lower() in nicks.values():
-        bot.send_message_parsed(event.conv, _('<i>Nickname "') + nickname + _('" is already in use by another user.</i>'))
+        bot.send_message_parsed(event.conv, _('<i>Nickname <b>`{}`</b> is already in use by another user').format(nickname))
         return
 
     bot.initialise_memory(event.user.id_.chat_id, "user_data")


### PR DESCRIPTION
Note: Title subject to change

Changelog:
* Fix for broken locale submodule
* Additional INSTALL guidance not to edit reference config.json (#246) + clarification in README
* Retrieve users missing in `bot._user_list` from permanent conversation memory (5112f7d)
* Tweaks for better translations
* Plugin: **convtools_invitations**
  * Test mode for `/bot invite` - adding parameter "test" anywhere in an invite command will make
    the bot dump the invite processing steps without committing anything to storage e.g. 
    `/bot invite from XYZ to GHI test`
  * `/bot invite list` and `/bot invite purge` now accepts optional parameter "expired" to allow listing
     and purging of expired invitations e.g. `/bot invite list expired` and `/bot invite purge expired`