### PR TITLE
failsafe memory for bot

### DIFF
--- a/hangupsbot/hangupsbot.py
+++ b/hangupsbot/hangupsbot.py
@@ -394,7 +394,7 @@ class HangupsBot(object):
             for chat_id in conv_data["participants"]:
                 all_users[chat_id] = self.get_hangups_user(chat_id) # by key for uniqueness
 
-        all_users = all_users.values()
+        all_users = list(all_users.values())
 
         return all_users
 

--- a/hangupsbot/hangupsbot.py
+++ b/hangupsbot/hangupsbot.py
@@ -93,7 +93,7 @@ class TypingEvent(StatusEvent):
         super().__init__(bot, state_update_event)
         self.user_id = state_update_event.user_id
         self.timestamp = state_update_event.timestamp
-        self.user = bot.get_hangups_user(state_update_event.user_id, self.conv_id)
+        self.user = bot.get_hangups_user(state_update_event.user_id)
         if self.user.is_self:
             self.from_bot = True
         self.text = "typing"
@@ -104,7 +104,7 @@ class WatermarkEvent(StatusEvent):
         super().__init__(bot, state_update_event)
         self.user_id = state_update_event.participant_id
         self.timestamp = state_update_event.latest_read_timestamp
-        self.user = bot.get_hangups_user(state_update_event.participant_id, self.conv_id)
+        self.user = bot.get_hangups_user(state_update_event.participant_id)
         if self.user.is_self:
             self.from_bot = True
         self.text = "watermark"
@@ -336,7 +336,7 @@ class HangupsBot(object):
 
         return convs
 
-    def get_hangups_user(self, user_id, conv_id=False):
+    def get_hangups_user(self, user_id):
         hangups_user = False
 
         if isinstance(user_id, str):
@@ -348,38 +348,28 @@ class HangupsBot(object):
 
         UserID = hangups.user.UserID(chat_id=chat_id, gaia_id=gaia_id)
 
-        try:
-            if self._user_list._self_user.id_.chat_id == chat_id:
-                """bot doesn't store itself in conversations catalog, so detect it explicitly"""
-                hangups_user = self._user_list._self_user
-
-            else:
-                try:
-                    """from hangups, if it exists"""
-                    hangups_user = self._user_list._user_dict[UserID]
-
-                except KeyError as e:
-                    """from permanent conversation memory"""
-                    if convid:
-                        conv_ids = [conv_id]
-                    else:
-                        # XXX: inefficient, search ALL conversations
-                        conv_ids = list(self.conversations.catalog.keys())
-
-                    for conv_id in conv_ids:
-                        cached_users = { u[0][0]: u for user in self.conversations.catalog[conv_id]["users"] }
-                        if chat_id in cached_users:
-                            UserID = hangups.user.UserID(
-                                chat_id=cached_users[chat_id][0][0],
-                                gaia_id=cached_users[chat_id][0][1])
-                            hangups_user = hangups.user.User(UserID, user[1], None, None, [], False)
-                            break
-
-        except Exception as e:
-            logging.exception("GET_HANGUPS_USER(): no valid hangups user {}".format(user_id))
-
+        """from hangups, if it exists"""
         if not hangups_user:
-            """if all else fails, create an "unknown" user"""
+            try:
+                hangups_user = self._user_list._user_dict[UserID]
+            except KeyError as e:
+                pass
+
+        """from permanent conversation user/memory"""
+        if not hangups_user:
+            if self.memory.exists(["user_data", chat_id, "_hangups"]):
+                _cached = self.memory.get_by_path(["user_data", chat_id, "_hangups"])
+
+                hangups_user = hangups.user.User(
+                    UserID, 
+                    _cached["full_name"],
+                    _cached["first_name"],
+                    _cached["photo_url"],
+                    _cached["emails"],
+                    _cached["is_self"] )
+
+        """if all else fails, create an "unknown" user"""
+        if not hangups_user:
             hangups_user = hangups.user.User(
                 UserID,
                 "unknown user",
@@ -392,9 +382,8 @@ class HangupsBot(object):
 
 
     def get_users_in_conversation(self, conv_ids):
-        """list all users in supplied conv_id(s).
-        supply many conv_id as a list.
-        """
+        """list all unique users in supplied conv_id or list of conv_ids"""
+
         if isinstance(conv_ids, str):
             conv_ids = [conv_ids]
         conv_ids = list(set(conv_ids))
@@ -402,13 +391,9 @@ class HangupsBot(object):
         all_users = {}
         for convid in conv_ids:
             conv_data = self.conversations.catalog[convid]
-            for user in conv_data["users"]:
-                UserID = hangups.user.UserID(chat_id=user[0][0], gaia_id=user[0][1])
-                try:
-                    hangups_user = self._user_list._user_dict[UserID]
-                except KeyError as e:
-                    hangups_user = hangups.user.User(UserID, user[1], None, None, [], False)
-                all_users[UserID] = hangups_user
+            for chat_id in conv_data["participants"]:
+                all_users[chat_id] = self.get_hangups_user(chat_id) # by key for uniqueness
+
         all_users = all_users.values()
 
         return all_users
@@ -604,6 +589,7 @@ class HangupsBot(object):
                                                    initial_data.conversation_states,
                                                    self._user_list,
                                                    initial_data.sync_timestamp)
+
         self._conv_list.on_event.add_observer(self._on_event)
 
         self._client.on_state_update.add_observer(self._on_status_changes)

--- a/hangupsbot/plugins/convtools_invitations.py
+++ b/hangupsbot/plugins/convtools_invitations.py
@@ -129,9 +129,9 @@ def _get_invites(bot, filter_active=True, filter_user=False):
     return invites
 
 
-def _get_user_list(bot, convid):
-    convlist = bot.conversations.get(convid)
-    return convlist[convid]["users"]
+def _get_user_list(bot, conv_id):
+    convlist = bot.conversations.get(conv_id)
+    return convlist[conv_id]["participants"]
 
 
 def invite(bot, event, *args):
@@ -320,9 +320,9 @@ def invite(bot, event, *args):
         shortlisted = []
         if sourceconv:
             sourceconv_users = _get_user_list(bot, sourceconv)
-            for u in sourceconv_users:
-                if everyone or u[0][0] in list_users:
-                    shortlisted.append(u[0][0])
+            for chat_id in sourceconv_users:
+                if everyone or chat_id in list_users:
+                    shortlisted.append(chat_id)
 
             invitation_log.append("shortlisted: {}/{}".format(len(shortlisted), len(sourceconv_users)))
             logging.info("convtools_invitations: shortlisted {}/{} from {}, everyone={}, list_users=[{}]".format(
@@ -337,12 +337,12 @@ def invite(bot, event, *args):
         """exclude users who are already in the target conversation"""
         if targetconv == "NEW_GROUP":
             # fake user list - _new_group_conversation() always creates group with bot and initiator
-            targetconv_users = [[[event.user.id_.chat_id]], [[bot.user_self()["chat_id"]]]]
+            targetconv_users = [ event.user.id_.chat_id, bot.user_self()["chat_id"] ]
         else:
             targetconv_users = _get_user_list(bot, targetconv)
         invited_users = []
         for uid in shortlisted:
-            if uid not in [u[0][0] for u in targetconv_users]:
+            if uid not in targetconv_users:
                 invited_users.append(uid)
             else:
                 invitation_log.append("excluding existing: {}".format(uid))

--- a/hangupsbot/plugins/default.py
+++ b/hangupsbot/plugins/default.py
@@ -39,7 +39,7 @@ def convfilter(bot, event, *args):
     else:
         lines = []
         for convid, convdata in bot.conversations.get(filter=posix_args[0]).items():
-            lines.append("`{}` <b>{}</b> ({})".format(convid, convdata["title"], len(convdata["users"])))
+            lines.append("`{}` <b>{}</b> ({})".format(convid, convdata["title"], len(convdata["participants"])))
         lines.append(_('<b>Total: {}</b>').format(len(lines)))
         bot.send_message_parsed(event.conv_id, '<br />'.join(lines))
 
@@ -116,21 +116,19 @@ def convusers(bot, event, *args):
         chunks = [] # one "chunk" = info for 1 hangout
         for convid, convdata in bot.conversations.get(filter=posix_args[0]).items():
             lines = []
-            lines.append('<b>{}</b>'.format(convdata["title"], len(convdata["users"])))
-            for user in convdata["users"]:
+            lines.append('<b>{}</b>'.format(convdata["title"], len(convdata["participants"])))
+            for chat_id in convdata["participants"]:
+                User = bot.get_hangups_user(chat_id)
                 # name and G+ link
                 _line = '<b><a href="https://plus.google.com/u/0/{}/about">{}</a></b>'.format(
-                    user[0][0], user[1])
+                    User.id_.chat_id, User.full_name)
                 # email from hangups UserList (if available)
-                user_id = hangups.user.UserID(chat_id=user[0][0], gaia_id=user[0][1])
-                if user_id in bot._user_list._user_dict:
-                    _u = bot._user_list._user_dict[user_id]
-                    if _u.emails:
-                        _line += '<br />... (<a href="mailto:{0}">{0}</a>)'.format(_u.emails[0])
+                if User.emails:
+                    _line += '<br />... (<a href="mailto:{0}">{0}</a>)'.format(User.emails[0])
                 # user id
-                _line += "<br />... {}".format(user[0][0]) # user id
+                _line += "<br />... {}".format(User.id_.chat_id) # user id
                 lines.append(_line)
-            lines.append(_('<b>Users: {}</b>').format(len(convdata["users"])))
+            lines.append(_('<b>Users: {}</b>').format(len(convdata["participants"])))
             chunks.append('<br />'.join(lines))
         text = '<br /><br />'.join(chunks) 
 
@@ -229,7 +227,7 @@ def broadcast(bot, event, *args):
             if parameters[0] == "groups":
                 """add all groups (chats with users > 1, bot not counted)"""
                 for convid, convdata in bot.conversations.get().items():
-                    if(len(convdata["users"]) > 1):
+                    if(len(convdata["participants"]) > 1):
                         _internal["broadcast"]["conversations"].append(convid)
             elif parameters[0] == "ALL":
                 """add EVERYTHING - try not to use this, will message 1-to-1s as well"""
@@ -280,7 +278,12 @@ def user(bot, event, username, *args):
     segments = [hangups.ChatMessageSegment(_('results for user named "{}":').format(username),
                                            is_bold=True),
                 hangups.ChatMessageSegment('\n', hangups.SegmentType.LINE_BREAK)]
-    for u in sorted(bot._user_list._user_dict.values(), key=lambda x: x.full_name.split()[-1]):
+
+    all_known_users = {}
+    for chat_id in bot.memory["user_data"]:
+        all_known_users[chat_id] = bot.get_hangups_user(chat_id)
+
+    for u in sorted(all_known_users.values(), key=lambda x: x.full_name.split()[-1]):
         if not username_lower in u.full_name.lower():
             continue
 

--- a/hangupsbot/plugins/unittest_convmem.py
+++ b/hangupsbot/plugins/unittest_convmem.py
@@ -12,6 +12,6 @@ def dumpconv(bot, event, *args):
     for convid, convdata in all_conversations:
         if text_search.lower() in convdata["title"].lower():
             lines.append("{} <em>{}</em> {}<br />... {} history: {} <br />... <b>{}</b>".format(
-                convid, convdata["source"], len(convdata["users"]), convdata["type"], convdata["history"], convdata["title"]))
+                convid, convdata["source"], len(convdata["participants"]), convdata["type"], convdata["history"], convdata["title"]))
     lines.append("<b><em>Totals: {}/{}</em></b>".format(len(lines), len(all_conversations)))
     bot.send_message_parsed(event.conv, "<br />".join(lines))

--- a/hangupsbot/utils.py
+++ b/hangupsbot/utils.py
@@ -68,14 +68,18 @@ class conversation_memory:
         sys.modules[__name__].bot = bot # workaround for drop-ins
 
     def load_from_hangups(self):
-        logging.info("conversation_memory(): loading from hangups")
-        for conv in self.bot._conv_list.get_all():
-            self.update(conv, source="init", automatic_save=False)
+        logging.info("convmem: loading users from hangups")
+        for User in self.bot._user_list.get_all():
+            self.store_user_memory(User, automatic_save=False, is_definitive=True)
+
+        logging.info("convmem: loading conversations from hangups")
+        for Conversation in self.bot._conv_list.get_all():
+            self.update(Conversation, source="init", automatic_save=False)
  
     def load_from_memory(self):
         if self.bot.memory.exists(['convmem']):
             convs = self.bot.memory.get_by_path(['convmem'])
-            logging.info("conversation_memory(): loading from memory {}".format(len(convs)))
+            logging.info("convmem(): loading conversations from memory {}".format(len(convs)))
             for convid in convs:
                 self.catalog[convid] = convs[convid]
 
@@ -103,9 +107,104 @@ class conversation_memory:
                 if "history" not in self.catalog[convid]:
                     self.catalog[convid]["history"] = True
 
+                if "participants" not in self.catalog[convid]:
+                    self.catalog[convid]["participants"] = [ u[0][0] for u in self.catalog[convid]["users"] ]
+
+                """add to permanent user memory if the record is valid"""
+
+                if len(self.catalog[convid]["users"]) > 0:
+                    _added = []
+
+                    for _u in self.catalog[convid]["users"]:
+                        UserID = hangups.user.UserID(chat_id=_u[0][0], gaia_id=_u[0][1])
+                        try:
+                            User = self.bot._user_list._user_dict[UserID]
+                            results = self.store_user_memory(
+                                User, is_definitive=True, automatic_save=False)
+
+                        except KeyError:
+                            User = hangups.user.User(
+                                UserID,
+                                _u[1],
+                                None,
+                                None,
+                                [],
+                                False)
+
+                            results = self.store_user_memory(
+                                User, is_definitive=False, automatic_save=False)
+
+                        if results:
+                            _added.append((_u[0][0], _u[1]))
+
+                    if len(_added) > 0:
+                        logging.info("convmem(): users added when loading {}: {}".format(
+                            convid, _added))
+
+
     def save_to_memory(self):
         self.bot.memory.set_by_path(['convmem'], self.catalog)
         self.bot.memory.save()
+
+
+    def store_user_memory(self, User, automatic_save=True, is_definitive=False):
+        self.bot.initialise_memory(User.id_.chat_id, "user_data")
+
+        cached = False
+        if self.bot.memory.exists(["user_data", User.id_.chat_id, "_hangups"]):
+            cached = self.bot.memory.get_by_path(["user_data", User.id_.chat_id, "_hangups"])
+            if "is_definitive" in cached and cached["is_definitive"] and is_definitive == False:
+                logging.info("convmem: user {} skipped update {}".format(cached["full_name"], cached["chat_id"]))
+                return False
+
+        user_dict ={
+            "chat_id": User.id_.chat_id,
+            "gaia_id": User.id_.gaia_id,
+            "full_name": User.full_name,
+            "first_name": User.first_name,
+            "photo_url": User.photo_url,
+            "emails": User.emails,
+            "is_self": User.is_self,
+            "is_definitive": is_definitive }
+
+        changed = False
+        if cached:
+            for key in list(user_dict.keys()):
+                try:
+                    if key == "emails":
+                        if set(user_dict[key]) != set(cached[key]):
+                            logging.info("convmem: user email changed {} ({})".format(User.full_name, User.id_.chat_id))
+                            changed = True
+                            break
+                    else:
+                        if user_dict[key] != cached[key]:
+                            logging.info("convmem: user {} changed {} ({})".format(key, User.full_name, User.id_.chat_id))
+                            changed = True
+                            break
+
+                except KeyError as e:
+                    logging.info("convmem: user {} missing {} ({})".format(key, User.full_name, User.id_.chat_id))
+                    changed = True
+                    break
+        else:
+            logging.info("convmem: new user {} ({})".format(User.full_name, User.id_.chat_id))
+            changed = True
+
+        if changed:
+            user_dict["updated"] = datetime.datetime.now().strftime("%Y%m%d%H%M%S")
+            self.bot.memory.set_by_path(["user_data", User.id_.chat_id, "_hangups"], user_dict)
+
+            if automatic_save:
+                self.save_to_memory()
+
+            logging.info("convmem: user {} updated {}".format(User.id_.chat_id, User.full_name))
+            return True
+
+        else:
+            logging.info("convmem: user {} unchanged {}".format(User.id_.chat_id, User.full_name))
+            return False
+
+
 
     def update(self, conv, source="unknown", automatic_save=True):
         conv_title = hangups_get_conv_name(conv)
@@ -124,6 +223,11 @@ class conversation_memory:
 
         """store the user list"""
         memory["users"] = [[[user.id_.chat_id, user.id_.gaia_id], user.full_name ] for user in conv.users if not user.is_self]
+
+        memory["participants"] = []
+        for User in conv.users:
+            memory["participants"].append(User.id_.chat_id)
+            self.store_user_memory(User, automatic_save, is_definitive=True)
 
         """store the conversation type: GROUP, ONE_TO_ONE"""
         if conv._conversation.type_ == hangups.schemas.ConversationType.GROUP:
@@ -147,19 +251,32 @@ class conversation_memory:
 
         if original:
             """existing tracked conversation"""
-            for key in ["title", "type", "history", "users"]:
-                if key == "users":
-                    """special processing for users list"""
-                    if (set([ (u[0][0], u[0][1], u[1]) for u in original["users"] ])
-                            != set([ (u[0][0], u[0][1], u[1]) for u in memory["users"] ])):
-                        logging.info("convmem: users changed {} ({})".format(conv_title, conv.id_))
-                        changed = True
-                        break
-                else:
-                    if original[key] != memory[key]:
-                        logging.info("convmem: {} changed {} ({})".format(key,  conv_title, conv.id_))
-                        changed = True
-                        break
+            for key in ["title", "type", "history", "users", "participants"]:
+                try:
+                    if key == "participants":
+                        if set(original["participants"]) != set(memory["participants"]):
+                            logging.info("convmem: participants changed {} ({})".format(conv_title, conv.id_))
+                            changed = True
+                            break
+
+                    elif key == "users":
+                        """special processing for users list"""
+                        if (set([ (u[0][0], u[0][1], u[1]) for u in original["users"] ])
+                                != set([ (u[0][0], u[0][1], u[1]) for u in memory["users"] ])):
+                            logging.info("convmem: users changed {} ({})".format(conv_title, conv.id_))
+                            changed = True
+                            break
+
+                    else:
+                        if original[key] != memory[key]:
+                            logging.info("convmem: {} changed {} ({})".format(key,  conv_title, conv.id_))
+                            changed = True
+                            break
+
+                except KeyError as e:
+                    logging.info("convmem: missing {} {} ({})".format(key,  conv_title, conv.id_))
+                    changed = True
+                    break
         else:
             """new conversation"""
             logging.info("convmem: new {} ({})".format(conv_title, conv.id_))

--- a/hangupsbot/utils.py
+++ b/hangupsbot/utils.py
@@ -226,7 +226,8 @@ class conversation_memory:
 
         memory["participants"] = []
         for User in conv.users:
-            memory["participants"].append(User.id_.chat_id)
+            if not User.is_self:
+                memory["participants"].append(User.id_.chat_id)
             self.store_user_memory(User, automatic_save, is_definitive=True)
 
         """store the conversation type: GROUP, ONE_TO_ONE"""

--- a/hangupsbot/utils.py
+++ b/hangupsbot/utils.py
@@ -343,10 +343,10 @@ class conversation_memory:
                     filtered[convid] = convdata
         elif filter.startswith("chat_id:"):
             # return all conversations user is in
-            chat_id = filter[8:]
+            filter_chat_id = filter[8:]
             for convid, convdata in self.catalog.items():
-                for user in convdata["users"]:
-                    if user[0][0] == chat_id:
+                for chat_id in convdata["participants"]:
+                    if filter_chat_id == chat_id:
                         filtered[convid] = convdata
 
         return filtered


### PR DESCRIPTION
* reduce disk i/o for convmem
* permanent user memory (like convmem)
  * created automatically in `memory[user_data][chat_id][_hangups]`
  * note: **doubles `memory.json` size**
* added simplified `participants` list of chat_id to each conversation memory
  * note: deprecated `convmem[users]` list for space reasons