### PR TITLE
Use proper directories for config/log/userdata files

### DIFF
--- a/hangupsbot/hangupsbot.py
+++ b/hangupsbot/hangupsbot.py
@@ -621,9 +621,9 @@ def main():
     """Main entry point"""
     # Build default paths for files.
     dirs = appdirs.AppDirs('hangupsbot', 'hangupsbot')
-    default_log_path = os.path.join(dirs.user_data_dir, 'hangupsbot.log')
+    default_log_path = os.path.join(dirs.user_log_dir, 'hangupsbot.log')
     default_cookies_path = os.path.join(dirs.user_data_dir, 'cookies.json')
-    default_config_path = os.path.join(dirs.user_data_dir, 'config.json')
+    default_config_path = os.path.join(dirs.user_config_dir, 'config.json')
     default_memory_path = os.path.join(dirs.user_data_dir, 'memory.json')
 
     # Configure argument parser


### PR DESCRIPTION
This change, as it now stands, is incompatible with the current way of doing things, so it really could use a bit of migration code to move the existing files, if they exist, to the right place.

The problem it's trying to "fix" is simply using AppDirs correctly and putting the right files in the right places. We currently throw everything in the user_data dir, which seems less insane on Linux than in other OSes, but is rather ugly in, say MacOS.

I'm perfectly OK with you rejecting it without migration code.