### PR TITLE
Restrict debugging messages to running under --debug

### DIFF
--- a/hangupsbot/handlers.py
+++ b/hangupsbot/handlers.py
@@ -192,16 +192,19 @@ class EventHandler:
                         _passed = args[0:len(_expected)]
                         if asyncio.iscoroutinefunction(function):
                             message.append(_("coroutine"))
-                            print(" : ".join(message))
+                            if logging.root.level == logging.DEBUG:
+                                print(" : ".join(message))
                             yield from function(*_passed)
                         else:
                             message.append(_("function"))
-                            print(" : ".join(message))
+                            if logging.root.level == logging.DEBUG:
+                                print(" : ".join(message))
                             function(*_passed)
                     except self.bot.Exceptions.SuppressHandler:
                         # skip this pluggable, continue with next
                         message.append(_("SuppressHandler"))
-                        print(" : ".join(message))
+                        if logging.root.level == logging.DEBUG:
+                            print(" : ".join(message))
                         pass
                     except (self.bot.Exceptions.SuppressEventHandling,
                             self.bot.Exceptions.SuppressAllHandlers):
@@ -215,7 +218,8 @@ class EventHandler:
             except self.bot.Exceptions.SuppressAllHandlers:
                 # skip all other pluggables, but let the event continue
                 message.append(_("SuppressAllHandlers"))
-                print(" : ".join(message))
+                if logging.root.level == logging.DEBUG:
+                    print(" : ".join(message))
                 pass
             except:
                 raise

--- a/hangupsbot/hangupsbot.py
+++ b/hangupsbot/hangupsbot.py
@@ -123,7 +123,8 @@ class HangupsBot(object):
         # load in previous memory, or create new one
         self.memory = None
         if memory_file:
-            print(_("HangupsBot: memory file will be used: {}").format(memory_file))
+            if logging.root.level == logging.DEBUG:
+                print(_("HangupsBot: memory file will be used: {}").format(memory_file))
             self.memory = config.Config(memory_file)
             if not os.path.isfile(memory_file):
                 try:

--- a/hangupsbot/sinks/__init__.py
+++ b/hangupsbot/sinks/__init__.py
@@ -54,7 +54,8 @@ def start(bot):
                 continue
 
             # start up rpc listener in a separate thread
-            print(_("_start_sinks(): {}").format(module))
+            if logging.root.level == logging.DEBUG:
+                print(_("_start_sinks(): {}").format(module))
 
             threadmanager.start_thread(start_listening, args=(
                 bot,


### PR DESCRIPTION
Cut down on some of the debug messages that aren't interesting when we're not debugging.