### PR TITLE
2.6.1 -> 2.7

### DIFF
--- a/hangupsbot/plugins/api.py
+++ b/hangupsbot/plugins/api.py
@@ -13,22 +13,16 @@ to be able to run admin commands externally
 
 More info: https://github.com/hangoutsbot/hangoutsbot/wiki/API-Plugin
 """
-import asyncio, json, logging, time, functools
+import asyncio, functools, json, logging, time
 
-from urllib.parse import urlparse, parse_qs, unquote
+from urllib.parse import unquote
 
 from aiohttp import web
 
-import hangups
-
 import plugins
-
-import threadmanager
 
 from sinks import aiohttp_start
 from sinks.base_bot_request_handler import AsyncRequestHandler
-
-from parsers.kludgy_html_parser import segment_to_html
 
 
 logger = logging.getLogger(__name__)
@@ -71,12 +65,12 @@ def _start_api(bot):
             try:
                 certfile = sinkConfig["certfile"]
                 if not certfile:
-                    print("config.api[{}].certfile must be configured".format(itemNo))
+                    logger.error("config.api[{}].certfile must be configured".format(itemNo))
                     continue
                 name = sinkConfig["name"]
                 port = sinkConfig["port"]
             except KeyError as e:
-                print("config.api[{}] missing keyword".format(itemNo), e)
+                logger.error("config.api[{}] missing keyword".format(itemNo), e)
                 continue
 
             aiohttp_start(bot, name, port, certfile, APIRequestHandler, group=__name__)

--- a/hangupsbot/sinks/github/simplepush.py
+++ b/hangupsbot/sinks/github/simplepush.py
@@ -1,72 +1,43 @@
-from http.server import BaseHTTPRequestHandler
-from urllib.parse import urlparse, parse_qs
+import asyncio, json, logging
 
-import asyncio, json
+from sinks.base_bot_request_handler import AsyncRequestHandler
 
-class webhookReceiver(BaseHTTPRequestHandler):
+
+logger = logging.getLogger(__name__)
+
+
+class webhookReceiver(AsyncRequestHandler):
     _bot = None
 
-    def _handle_incoming(self, path, query_string, payload):
+    @asyncio.coroutine
+    def process_request(self, path, query_string, content):
         path = path.split("/")
-        conversation_id = path[1]
-        if conversation_id is None:
-            print(_("conversation id must be provided as part of path"))
+        conv_or_user_id = path[1]
+        if conv_or_user_id is None:
+            logger.error("conversation or user id must be provided as part of path")
             return
 
+        try:
+            payload = json.loads(content)
+        except Exception as e:
+            logger.exception("invalid payload")
+
         if "repository" in payload and "commits" in payload and "pusher" in payload:
-            self._github_push(conversation_id, payload)
+            html = '<b>{0}</b> has <a href="{2}">pushed</a> {1} commit(s)<br />'.format( payload["pusher"]["name"],
+                                                                                         len(payload["commits"]),
+                                                                                         payload["repository"]["url"] )
+
+            for commit in payload["commits"]:
+                html += '* <i>{0}</i> <a href="{2}">link</a><br />'.format( commit["message"],
+                                                                            commit["author"]["name"],
+                                                                            commit["url"],
+                                                                            commit["timestamp"],
+                                                                            commit["id"] )
+
+            yield from self.send_data(conv_or_user_id, html)
+
+        elif "zen" in payload:
+            logger.info("github zen received: {}".format(payload["zen"]))
+
         else:
-            print(payload)
-
-        print(_("handler finished"))
-
-
-    def _github_push(self, conversation_id, json):
-        html = '<b>{0}</b> has <a href="{2}">pushed</a> {1} commit(s)<br />'.format(
-          json["pusher"]["name"],
-          len(json["commits"]),
-          json["repository"]["url"])
-
-        for commit in json["commits"]:
-            html += '* <i>{0}</i> <a href="{2}">link</a><br />'.format(
-              commit["message"],
-              commit["author"]["name"],
-              commit["url"],
-              commit["timestamp"],
-              commit["id"])
-
-        asyncio.async(
-            webhookReceiver._bot.coro_send_message(conversation_id, html)
-        ).add_done_callback(lambda future: future.result())
-
-
-    def do_POST(self):
-        """
-            receives post, handles it
-        """
-        print(_('receiving POST...'))
-        data_string = self.rfile.read(int(self.headers['Content-Length'])).decode('UTF-8')
-        self.send_response(200)
-        message = bytes('OK', 'UTF-8')
-        self.send_header("Content-type", "text")
-        self.send_header("Content-length", str(len(message)))
-        self.end_headers()
-        self.wfile.write(message)
-        print(_('connection closed'))
-
-        # parse requested path + query string
-        _parsed = urlparse(self.path)
-        path = _parsed.path
-        query_string = parse_qs(_parsed.query)
-
-        print(_("incoming path: {}").format(path))
-
-        # parse incoming data
-        payload = json.loads(data_string)
-
-        self._handle_incoming(path, query_string, payload)
-
-
-    def log_message(self, formate, *args):
-        # disable printing to stdout/stderr for every post
-        return
+            logger.error("unrecognised payload: {}".format(payload))

--- a/hangupsbot/sinks/gitlab/simplepush.py
+++ b/hangupsbot/sinks/gitlab/simplepush.py
@@ -1,78 +1,45 @@
-from http.server import BaseHTTPRequestHandler
-from urllib.parse import urlparse, parse_qs
+import asyncio, json, logging
 
-import asyncio, json
+from sinks.base_bot_request_handler import AsyncRequestHandler
 
-class webhookReceiver(BaseHTTPRequestHandler):
+
+logger = logging.getLogger(__name__)
+
+
+class webhookReceiver(AsyncRequestHandler):
     _bot = None
 
-    def _handle_incoming(self, path, query_string, payload):
-        """gitlab-specific handling"""
+    @asyncio.coroutine
+    def process_request(self, path, query_string, content):
+        path = path.split("/")
+        conv_or_user_id = path[1]
+        if conv_or_user_id is None:
+            logger.error("conversation or user id must be provided as part of path")
+            return
+
+        try:
+            payload = json.loads(content)
+        except Exception as e:
+            logger.exception("invalid payload")
+
         try:
             object_kind = payload["object_kind"]
         except KeyError:
             object_kind = 'push'
 
-        path = path.split("/")
-        conversation_id = path[1]
-        if conversation_id is None:
-            print(_("conversation id must be provided as part of path"))
-            return
-
         if object_kind == 'push':
-            self._gitlab_push(conversation_id, payload)
+            html = '<b>{0}</b> has <a href="{2}">pushed</a> {1} commit(s)<br />'.format( payload["user_name"],
+                                                                                         payload["total_commits_count"],
+                                                                                         payload["repository"]["url"] )
+
+            for commit in payload["commits"]:
+                html += '* <i>{0}</i> <a href="{2}">link</a><br />'.format( commit["message"],
+                                                                            commit["author"]["name"],
+                                                                            commit["url"],
+                                                                            commit["timestamp"],
+                                                                            commit["id"] )
+
+            yield from self.send_data(conv_or_user_id, html)
+
         else:
-            print(payload)
-
-        print(_("handler finished"))
-
-
-    def _gitlab_push(self, conversation_id, json):
-        html = '<b>{0}</b> has <a href="{2}">pushed</a> {1} commit(s)<br />'.format(
-          json["user_name"],
-          json["total_commits_count"],
-          json["repository"]["url"])
-
-        for commit in json["commits"]:
-            html += '* <i>{0}</i> <a href="{2}">link</a><br />'.format(
-              commit["message"],
-              commit["author"]["name"],
-              commit["url"],
-              commit["timestamp"],
-              commit["id"])
-
-        asyncio.async(
-            webhookReceiver._bot.coro_send_message(conversation_id, html)
-        ).add_done_callback(lambda future: future.result())
-
-
-    def do_POST(self):
-        """
-            receives post, handles it
-        """
-        print(_('receiving POST...'))
-        data_string = self.rfile.read(int(self.headers['Content-Length'])).decode('UTF-8')
-        self.send_response(200)
-        message = bytes('OK', 'UTF-8')
-        self.send_header("Content-type", "text")
-        self.send_header("Content-length", str(len(message)))
-        self.end_headers()
-        self.wfile.write(message)
-        print(_('connection closed'))
-
-        # parse requested path + query string
-        _parsed = urlparse(self.path)
-        path = _parsed.path
-        query_string = parse_qs(_parsed.query)
-
-        print(_("incoming path: {}").format(path))
-
-        # parse incoming data
-        payload = json.loads(data_string)
-
-        self._handle_incoming(path, query_string, payload)
-
-
-    def log_message(self, formate, *args):
-        # disable printing to stdout/stderr for every post
-        return
+            logger.info("payload is not push: {}".format(payload))

--- a/hangupsbot/version.py
+++ b/hangupsbot/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.7.beta"
+__version__ = "2.7"

--- a/hangupsbot/version.py
+++ b/hangupsbot/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.6.2.beta"
+__version__ = "2.7.beta"


### PR DESCRIPTION
# Deprecation Notices

* The following **[Message Sending](https://github.com/hangoutsbot/hangoutsbot/wiki/Message-Sending)** functions are **soft-deprecated** and will raise `[DEPRECATED]` DEBUG notices in the log if they are used (4fb92c6):
  * ~~`bot.send_message()`~~ - ~~replace with **[bot.coro_send_message()](https://github.com/hangoutsbot/hangoutsbot/wiki/Message-Sending#messaging-arbitrary-conversation)**~~ [*un-deprecated*](https://github.com/hangoutsbot/hangoutsbot/wiki/Message-Sending#messaging-arbitrary-conversation) in 652901e
  * `bot.send_message_parsed()` - replace with **[bot.coro_send_message()](https://github.com/hangoutsbot/hangoutsbot/wiki/Message-Sending#messaging-arbitrary-conversation)**
  * `bot.send_message_segments()` - replace with **[bot.coro_send_message()](https://github.com/hangoutsbot/hangoutsbot/wiki/Message-Sending#messaging-arbitrary-conversation)**
  * `bot.send_html_to_conversation()` - replace with **[bot.coro_send_message()](https://github.com/hangoutsbot/hangoutsbot/wiki/Message-Sending#messaging-arbitrary-conversation)**
* The following **[Message Sending](https://github.com/hangoutsbot/hangoutsbot/wiki/Message-Sending)** functions are **hard-deprecated** and will raise `[DEPRECATED]` WARNINGS in the logger and on console if they are used:
  * `bot.external_send_message()` - replace with **[bot.coro_send_message()](https://github.com/hangoutsbot/hangoutsbot/wiki/Message-Sending#messaging-arbitrary-conversation)**
  * `bot.external_send_message_parsed()` - replace with **[bot.coro_send_message()](https://github.com/hangoutsbot/hangoutsbot/wiki/Message-Sending#messaging-arbitrary-conversation)**
  * `bot.send_html_to_user()` - replace with **[bot.coro_send_to_user()](https://github.com/hangoutsbot/hangoutsbot/wiki/Message-Sending#messaging-user-via-1-to-1)**
  * `send_html_to_user_or_conversation` - replace with combination of **[bot.coro_send_message()](https://github.com/hangoutsbot/hangoutsbot/wiki/Message-Sending#messaging-arbitrary-conversation)** and **[bot.coro_send_to_user()](https://github.com/hangoutsbot/hangoutsbot/wiki/Message-Sending#messaging-user-via-1-to-1)**
* The [**Pre-2.4 Plugin Pattern**](https://github.com/hangoutsbot/hangoutsbot/wiki/Plugin-Authoring-(2.3.4-and-below))  is **hard-deprecated** and continued usage will raise `[DEPRECATED]` WARNINGS in the logger and on console if they are used. (re: #301, 5712455)
  * Modernised plugin patterns: **Forwarding** (1093a72), **Image Links** (6adfa98), **Mentions** (dfaa9f2), **SimplyTranslate** (8ed1bab), **Slack** (52b52cf), **Subscribe** (1e8922e)
  * **PLUGIN DEVELOPERS: [Please migrate](https://github.com/hangoutsbot/hangoutsbot/wiki/Migrating-Pre-2.4-Plugins)**

# Features

* **[Access Control with Tags](https://github.com/hangoutsbot/hangoutsbot/wiki/Access-Control-with-Tags)** (re: #293)
* **System Plugins** which provides a [richer core command set](https://github.com/hangoutsbot/hangoutsbot/wiki/Core-Commands) for bots (re: #293)
  * Note: If you receive warnings for missing plugin [**unittest_convmem**](https://github.com/hangoutsbot/hangoutsbot/wiki/Permanent-Memory#Permamem_Diagnostics__Repair) or [**unittest_tags**](https://github.com/hangoutsbot/hangoutsbot/wiki/Users-and-Conversations-Tagging#basic-tag-manipulation), please remove the entries from your manually-configured [`config["plugins"]`](https://github.com/hangoutsbot/hangoutsbot/wiki/Configuration#plugins) key, as both plugins have been integrated as system plugins
  * **New Plugin Control Commands** allows load/unload/reload of all plugins - except threaded ones due to platform constraints (b20d29b)
* [**(Python) Logger to Chat Message**](https://github.com/hangoutsbot/hangoutsbot/wiki/Logger-to-Chat-Message) provides simple redirection of log messages to any conversations tagged `receive-logs` (re: #196, 4e3c7cf)
* **`aiohttp.web` sinks** - faster than threaded sinks by order of a magnitude (6492d7f)
  * adds `AsyncRequestHandler` as counterpart to `BaseBotRequestHandler`
  * framework function `sinks.aiohttp_start()` to start aiohttp.web sinks
  * smart sinks loader starts `config[json_rpc]`-configured sink based on parent class `AsyncRequestHandler` or `BaseBotRequestHandler`
  * **webbridge** framework feature updated to use `AsyncRequestHandler` - reduces response time for webbridge-based **Hubot** plugin (376dc61) 
* **Long-running `asyncio.task`**, replaces threads, start a task by registering a long-running coroutine function with `plugins.register_asyncio_task(coroutine_function, [<extra arguments>])` - `bot` is always passed as the first parameter to the registered function

# Plugins and Sinks

* **`AsyncMessagePoster`** is a **NEW SINK** that is a drop-in replacement for `SimpleMessagePoster` - uses `AsyncRequestHandler` for faster response time to incoming requests
* **Restricted Add** - Bugfix: Prevent bot from making itself a botkeeper even if the bot id has been added to `config["admins"]` (re: #303, e87dd30)
* **Namelock** - Enhancement: Update locked topic if authorised user (bot, admin) renames the conversation (re: #304, 22ec152)
* **Slack** - Enhancement: More informative errors on configuration/initialisation errors (re: #306, re: #238, 52b52cf); Re-factored to use `AsyncRequestHandler` (6492d7f)
* **Google Script Sink** - Enhancement: Upgraded to use [BaseBotRequestHandler](https://github.com/hangoutsbot/hangoutsbot/wiki/BaseBotRequestHandler-Class) (re: #297,  51080dc); improved test script (4cbd7fd); new [wiki page] (https://github.com/hangoutsbot/hangoutsbot/wiki/Google-Script-Sink); Refactored to use `AsyncRequestHandler` (4d623bd)
* **Cleverbot** - Bugfix: Fix broken API with code adapted from latest [folz/cleverbot.py](https://github.com/folz/cleverbot.py) (e5e5216); Enhancement: Prevent bot hangs when plugin is busy (re: #187, d7b96ea)
* **BotAlive** - Bugfix: Prevent critical errors in the plugin from quitting the bot (2d5ca57) - also applied as an emergency fix to master via [2.6.1.patch-1 release](https://github.com/hangoutsbot/hangoutsbot/releases/tag/2.6.1.patch-1); Enhancement: Refactored as a long-running `asyncio.task` (d7273fa); Added configurable timing (e6dd08d); [Wiki updated](https://github.com/hangoutsbot/hangoutsbot/wiki/Botalive-Plugin)
* **Syncrooms** - Enhancement: Remove redundant "Incoming image..." (f1f93b1)
* **Forwarding** - Enhancement: Remove redundant "Incoming image..." (396c2d5)
* **TLDR** - Bugfix: Prevent `memory.json` corruption on preloaded entries (b2f230b) - also applied as an emergency fix to master via [2.6.1.patch-2 release](https://github.com/hangoutsbot/hangoutsbot/releases/tag/2.6.1.patch-2); Bugfix: Regression with TLDR sorting introduced with corruption fix (a099e4f via #309, thanks @j16sdiz!)
* **Default** - Bugfix/Enhancement: Fix broken `/bot broadcast remove` sub-command and potential markup mangling in `/bot broadcast info` output (re: #313, 21b3603)
* **API** - Enhancement: Return command output (requires a command to return dictionary containing key `api.response`); Re-factored to use `AsyncRequestHandler` (6492d7f)
  * `ping` (9109bca), `convfilter`, `convusers` (32542ee) modified to return command output
* **Github Push Listener** - Enhancement: Refactored to use `AsyncRequestHandler` (re: #326, 0fce5e9)
* **Gitlab Push Listener** - Enhancement: Refactored to use `AsyncRequestHandler` (re: #326, 0fce5e9)

# Other Changes & Upgrades

* Framework automatically monkey-patches OTR support into hangups for `adduser` and `removeuser` - bot obeys OTR status when adding users and leaving a conversation (re: #302, e2f3263)
* [Force OTR flag](https://github.com/hangoutsbot/hangoutsbot/wiki/Message-Sending#force-off-the-record-otr-flag) when sending specific messages by using `context` parameter (re: #299, d7a7272)
* Sinks: More informative errors when `.pem` file is missing (re: #305 + #306, e97e9b4, 5735ee7); address is in use (re: #306, 5735ee7); and when `.pem` file is corrupt or invalid (re: #306, df696d6)
* [`config["autocreate-1to1"]`](https://github.com/hangoutsbot/hangoutsbot/wiki/Configuration#autocreate1to1) is now defaulted ON (re: #202, 76c9848)
* **[bot.coro_send_message()](https://github.com/hangoutsbot/hangoutsbot/wiki/Message-Sending#messaging-arbitrary-conversation)** implemented as the replacement for `bot.send_message_parsed()`, `bot.send_html_to_conversation()`, `bot.send_message_segments` and `bot.send_message` (90df3fd, 9811441, 375d8f0)
  * Older functions will continue to work but will be deprecated and obsoleted in upcoming versions. Plugin developers are encouraged to update their older patterns since this is a drop-in replacement.
  * Plugins updated: **Image Links** (873a337), **Core: Basic** (01de566), **Namelock** (30cd891), **Autoreply** (3ad1a46), **Cleverbot** (3ad1a46), **Reddit Image Linker** (3ad1a46, b8b75b9), **Lookup** (3ad1a46), **MonitorAdds** (3ad1a46), **unittest_geticon** (3ad1a46), **WolframAlpha** (3ad1a46), **TLDR** (7728df3), **Meme Generator Images** (7728df3, b8b75b9), **Forwarding** (7728df3), **Conversation Tools** (7fb9256), **Conversation Invitations** (7fb9256), **Image Screenshot** (7fb9256), **Syncrooms** (f1f93b1), **Default** (727c3ec), **Forwarding** (396c2d5), **Botalias** (c6c4f63), **Chance** (c6c4f63), **DND** (c6c4f63), **Hangout Calls Humor** (c6c4f63), **Syncroom Autotranslate** (c6c4f63), **Syncroom Config** (c6c4f63), **Memory Example** (0a68b65), **Lottery** (0a68b65), **SimpleWikipedia** (0a68b65), **SimplyTranslate** (0a68b65), **Starter** (0a68b65), **Urbandict** (0a68b65), **Mentions** (b720d1a), **Subscribe** (b720d1a), **Restricted Add** (b720d1a), **Core: CONVID** (0c39d68), **Core: Permamem** (0c39d68), **Core: Tagging** (0c39d68), **unittest_reprocessor** (892d95c), **Slack** (cc73294), **API** (cc73294)
  * Sinks updated: **gitlab** (cc73294), **github** (cc73294), **Google Script Sink** (cc73294), **simpledemo** (fc8582e)
  * Framework Components Updated: **CommandDispatcher** (0c39d68), *event handling* (892d95c), **BaseBotRequestHandler** (fc8582e)
* **Reprocessor** supports asyncio.coroutine or conventional function as mapped function - **unittest_reprocessor** updated to demonstrate both mechanisms (892d95c)
* Direct API call to `bot._client.removeuser()` instead of OOP fluff in `convleave` (107601a) 
* Command Dispatcher will now try and match case-insensitive command if it cannot find a case-sensitive matching command (re: #314, 46f4c26)
* Additional plugins updated to reflect python logging convention (re: #319, 7a58dc6, thanks @pleasantone!)
* All unittests and example plugins are deactivated on default configuration (re: #320, 947a052, per @pleasantone's suggestion)
* Override the default python logging settings by bootstrapping config (re: #321, #324, 55e20b9, thanks @pleasantone)


# Documentation

* *PEM Generation* instructions separated moved to [new wiki page](https://github.com/hangoutsbot/hangoutsbot/wiki/PEM-File-Generation)
* *Google Scripts Sink setup and configuration* moved to [new wiki page](https://github.com/hangoutsbot/hangoutsbot/wiki/Google-Script-Sink)
* Page conversion from GFM to Mediawiki format (for automated Table-of-Contents generation):
  * https://github.com/hangoutsbot/hangoutsbot/wiki/Access-Control-with-Tags
  * https://github.com/hangoutsbot/hangoutsbot/wiki/Configuration
  * https://github.com/hangoutsbot/hangoutsbot/wiki/Customising-Access-Control
  * https://github.com/hangoutsbot/hangoutsbot/wiki/Permanent-Memory
  * https://github.com/hangoutsbot/hangoutsbot/wiki/Role-Based-Access-System-Discussion
  * https://github.com/hangoutsbot/hangoutsbot/wiki/Users-and-Conversations-Tagging
* Page renames for compatibility with Window:
  * https://github.com/hangoutsbot/hangoutsbot/wiki/Reference:-BaseBotRequestHandler-Class to **https://github.com/hangoutsbot/hangoutsbot/wiki/BaseBotRequestHandler-Class**
  * https://github.com/hangoutsbot/hangoutsbot/wiki/Reference:-hangups-state_update-dumps to **https://github.com/hangoutsbot/hangoutsbot/wiki/hangups-state_update-dumps**
  * https://github.com/hangoutsbot/hangoutsbot/wiki/Reference:-Manipulating-config.json to **https://github.com/hangoutsbot/hangoutsbot/wiki/Accessing-and-Writing-config.json**
  * https://github.com/hangoutsbot/hangoutsbot/wiki/Reference:-Permanent-Conversation-Memory, https://github.com/hangoutsbot/hangoutsbot/wiki/Permanent-Conversation-Memory, https://github.com/hangoutsbot/hangoutsbot/wiki/Reference:-Permanent-Memory-(permamem), https://github.com/hangoutsbot/hangoutsbot/wiki/Permanent-Memory-(permamem)
 to **https://github.com/hangoutsbot/hangoutsbot/wiki/Permanent-Memory**
  * https://github.com/hangoutsbot/hangoutsbot/wiki/Reference:-Manipulating-memory.json to **https://github.com/hangoutsbot/hangoutsbot/wiki/Accessing-and-Writing-memory.json**
  * https://github.com/hangoutsbot/hangoutsbot/wiki/Reference:-Sending-Messages to **https://github.com/hangoutsbot/hangoutsbot/wiki/Message-Sending**
  * https://github.com/hangoutsbot/hangoutsbot/wiki/Reference:-Tags-List to **https://github.com/hangoutsbot/hangoutsbot/wiki/Tags-List**
  * https://github.com/hangoutsbot/hangoutsbot/wiki/Reference:-User-and-Conversation-Tagging to **https://github.com/hangoutsbot/hangoutsbot/wiki/Users-and-Conversations-Tagging**