### PR TITLE
bugfix: memory corruption bug with preloaded tldrs

### DIFF
--- a/hangupsbot/plugins/tldr.py
+++ b/hangupsbot/plugins/tldr.py
@@ -29,7 +29,7 @@ def tldr(bot, event, *args):
     chat_tldr = bot.memory.get_by_path(['tldr', event.conv_id])
 
     if tldr: # Add message to list
-        chat_tldr[time.time()] = tldr
+        chat_tldr[str(time.time())] = tldr
         bot.memory.set_by_path(['tldr', event.conv_id], chat_tldr)
         bot.send_html_to_conversation(event.conv_id, "Added '{}' to TL;DR. Now at {} entries".format(tldr, len(chat_tldr)))
     else: # Display all messages


### PR DESCRIPTION
an obscure bug with the tldr module can result in memory corruption when re-loading the bot