### PR TITLE
Link names in Slack so a HO user can @-reply a Slack user

### DIFF
--- a/hangupsbot/plugins/slack.py
+++ b/hangupsbot/plugins/slack.py
@@ -191,7 +191,7 @@ def _handle_slackout(bot, event, command):
                     except TypeError:
                         client = SlackClient(slackkey)
 
-                    client.chat_post_message(channel, event.text, username=fullname, icon_url=photo_url)
+                    client.chat_post_message(channel, event.text, username=fullname, icon_url=photo_url, link_names=1)
 
             except Exception as e:
                 logger.exception( "Could not handle slackout with key {} between {} and {}."


### PR DESCRIPTION
The title says it all, slack API just needed to be signaled so that it will check parsing for things like @names and #channels appropriately.