### PR TITLE
framework file reorganisation, logging, slack

### DIFF
--- a/hangupsbot/events.py
+++ b/hangupsbot/events.py
@@ -1,0 +1,67 @@
+import hangups
+
+class StatusEvent:
+    """base class for all non-ConversationEvent
+        TypingEvent
+        WatermarkEvent
+    """
+    def __init__(self, bot, state_update_event):
+        self.conv_event = state_update_event
+        self.conv_id = state_update_event.conversation_id.id_
+        self.conv = None
+        self.event_id = None
+        self.user_id = None
+        self.user = None
+        self.timestamp = None
+        self.text = ''
+        self.from_bot = False
+
+
+class TypingEvent(StatusEvent):
+    def __init__(self, bot, state_update_event):
+        super().__init__(bot, state_update_event)
+        self.user_id = state_update_event.user_id
+        self.timestamp = state_update_event.timestamp
+        self.user = bot.get_hangups_user(state_update_event.user_id)
+        if self.user.is_self:
+            self.from_bot = True
+        self.text = "typing"
+
+
+class WatermarkEvent(StatusEvent):
+    def __init__(self, bot, state_update_event):
+        super().__init__(bot, state_update_event)
+        self.user_id = state_update_event.participant_id
+        self.timestamp = state_update_event.latest_read_timestamp
+        self.user = bot.get_hangups_user(state_update_event.participant_id)
+        if self.user.is_self:
+            self.from_bot = True
+        self.text = "watermark"
+
+
+class ConversationEvent(object):
+    """Conversation event"""
+    def __init__(self, bot, conv_event):
+        self.conv_event = conv_event
+        self.conv_id = conv_event.conversation_id
+        self.conv = bot._conv_list.get(self.conv_id)
+        self.event_id = conv_event.id_
+        self.user_id = conv_event.user_id
+        self.user = self.conv.get_user(self.user_id)
+        self.timestamp = conv_event.timestamp
+        self.text = conv_event.text.strip() if isinstance(conv_event, hangups.ChatMessageEvent) else ''
+
+    def print_debug(self, bot=None):
+        """Print informations about conversation event"""
+        print('eid/dtime: {}/{}'.format(self.event_id, self.timestamp.astimezone(tz=None).strftime('%Y-%m-%d %H:%M:%S')))
+        if not bot:
+            # don't crash on old usage, instruct dev to supply bot
+            print('cid/cname: {}/undetermined, supply parameter: bot'.format(self.conv_id))
+        else:
+            print('cid/cname: {}/{}'.format(self.conv_id, bot.conversations.get_name(self.conv)))
+        if self.user_id.chat_id == self.user_id.gaia_id:
+            print('uid/uname: {}/{}'.format(self.user_id.chat_id, self.user.full_name))
+        else:
+            print('uid/uname: {}!{}/{}'.format(self.user_id.chat_id, self.user_id.gaia_id, self.user.full_name))
+        print('txtlen/tx: {}/{}'.format(len(self.text), self.text))
+        print('eventdump: completed --8<--')

--- a/hangupsbot/exceptions.py
+++ b/hangupsbot/exceptions.py
@@ -1,0 +1,16 @@
+class SuppressHandler(Exception):
+    pass
+
+class SuppressAllHandlers(Exception):
+    pass
+
+class SuppressEventHandling(Exception):
+    pass
+
+
+class HangupsBotExceptions:
+    def __init__(self):
+        self.SuppressHandler = SuppressHandler
+        self.SuppressAllHandlers = SuppressAllHandlers
+        self.SuppressEventHandling = SuppressEventHandling
+

--- a/hangupsbot/handlers.py
+++ b/hangupsbot/handlers.py
@@ -32,7 +32,9 @@ class EventHandler:
                             "typing": [],
                             "watermark": [] }
 
-        bot.register_shared('reprocessor.attach_reprocessor', self.attach_reprocessor)
+        bot.register_shared( 'reprocessor.attach_reprocessor',
+                             self.attach_reprocessor,
+                             forgiving=True )
 
 
     def register_handler(self, function, type="message", priority=50):

--- a/hangupsbot/hangups_conversation.py
+++ b/hangupsbot/hangups_conversation.py
@@ -142,3 +142,22 @@ class HangupsConversation(hangups.conversation.Conversation):
     @property
     def users(self):
         return [ self.bot.get_hangups_user(part.id_.chat_id) for part in self._conversation.participant_data ]
+
+
+class FakeConversation(object):
+    def __init__(self, _client, id_):
+        self._client = _client
+        self.id_ = id_
+
+    @asyncio.coroutine
+    def send_message(self, segments, image_id=None, otr_status=None):
+        with (yield from asyncio.Lock()):
+            if segments:
+                serialised_segments = [seg.serialize() for seg in segments]
+            else:
+                serialised_segments = None
+
+            yield from self._client.sendchatmessage(
+                self.id_, serialised_segments,
+                image_id=image_id, otr_status=otr_status
+            )

--- a/hangupsbot/hangupsbot.py
+++ b/hangupsbot/hangupsbot.py
@@ -16,115 +16,16 @@ import hooks
 import sinks
 import plugins
 
+from exceptions import HangupsBotExceptions
+from events import (TypingEvent, WatermarkEvent, ConversationEvent)
+from hangups_conversation import (HangupsConversation, FakeConversation)
+
 from commands import command
-from hangups_conversation import HangupsConversation
 from permamem import conversation_memory
 from utils import simple_parse_to_segments, class_from_name
 
 
 gettext.install('hangupsbot', localedir=os.path.join(os.path.dirname(__file__), 'locale'))
-
-
-class SuppressHandler(Exception):
-    pass
-
-class SuppressAllHandlers(Exception):
-    pass
-
-class SuppressEventHandling(Exception):
-    pass
-
-class HangupsBotExceptions:
-    def __init__(self):
-        self.SuppressHandler = SuppressHandler
-        self.SuppressAllHandlers = SuppressAllHandlers
-        self.SuppressEventHandling = SuppressEventHandling
-
-
-class FakeConversation(object):
-    def __init__(self, _client, id_):
-        self._client = _client
-        self.id_ = id_
-
-    @asyncio.coroutine
-    def send_message(self, segments, image_id=None, otr_status=None):
-        with (yield from asyncio.Lock()):
-            if segments:
-                serialised_segments = [seg.serialize() for seg in segments]
-            else:
-                serialised_segments = None
-
-            yield from self._client.sendchatmessage(
-                self.id_, serialised_segments,
-                image_id=image_id, otr_status=otr_status
-            )
-
-
-class StatusEvent:
-    """base class for all non-ConversationEvent
-        TypingEvent
-        WatermarkEvent
-    """
-    def __init__(self, bot, state_update_event):
-        self.conv_event = state_update_event
-        self.conv_id = state_update_event.conversation_id.id_
-        self.conv = None
-        self.event_id = None
-        self.user_id = None
-        self.user = None
-        self.timestamp = None
-        self.text = ''
-        self.from_bot = False
-
-
-class TypingEvent(StatusEvent):
-    def __init__(self, bot, state_update_event):
-        super().__init__(bot, state_update_event)
-        self.user_id = state_update_event.user_id
-        self.timestamp = state_update_event.timestamp
-        self.user = bot.get_hangups_user(state_update_event.user_id)
-        if self.user.is_self:
-            self.from_bot = True
-        self.text = "typing"
-
-
-class WatermarkEvent(StatusEvent):
-    def __init__(self, bot, state_update_event):
-        super().__init__(bot, state_update_event)
-        self.user_id = state_update_event.participant_id
-        self.timestamp = state_update_event.latest_read_timestamp
-        self.user = bot.get_hangups_user(state_update_event.participant_id)
-        if self.user.is_self:
-            self.from_bot = True
-        self.text = "watermark"
-
-
-class ConversationEvent(object):
-    """Conversation event"""
-    def __init__(self, bot, conv_event):
-        self.conv_event = conv_event
-        self.conv_id = conv_event.conversation_id
-        self.conv = bot._conv_list.get(self.conv_id)
-        self.event_id = conv_event.id_
-        self.user_id = conv_event.user_id
-        self.user = self.conv.get_user(self.user_id)
-        self.timestamp = conv_event.timestamp
-        self.text = conv_event.text.strip() if isinstance(conv_event, hangups.ChatMessageEvent) else ''
-
-    def print_debug(self, bot=None):
-        """Print informations about conversation event"""
-        print('eid/dtime: {}/{}'.format(self.event_id, self.timestamp.astimezone(tz=None).strftime('%Y-%m-%d %H:%M:%S')))
-        if not bot:
-            # don't crash on old usage, instruct dev to supply bot
-            print('cid/cname: {}/undetermined, supply parameter: bot'.format(self.conv_id))
-        else:
-            print('cid/cname: {}/{}'.format(self.conv_id, bot.conversations.get_name(self.conv)))
-        if self.user_id.chat_id == self.user_id.gaia_id:
-            print('uid/uname: {}/{}'.format(self.user_id.chat_id, self.user.full_name))
-        else:
-            print('uid/uname: {}!{}/{}'.format(self.user_id.chat_id, self.user_id.gaia_id, self.user.full_name))
-        print('txtlen/tx: {}/{}'.format(len(self.text), self.text))
-        print('eventdump: completed --8<--')
 
 
 class HangupsBot(object):

--- a/hangupsbot/plugins/slack.py
+++ b/hangupsbot/plugins/slack.py
@@ -191,7 +191,14 @@ def _handle_slackout(bot, event, command):
                     except TypeError:
                         client = SlackClient(slackkey)
 
-                    client.chat_post_message(channel, event.text, username=fullname, icon_url=photo_url, link_names=1)
+                    slack_api_params = { 'username': fullname,
+                                         'icon_url': photo_url }
+
+                    if "link_names" not in sinkConfig or sinkConfig["link_names"]:
+                        logger.debug("slack api link_names is active")
+                        slack_api_params["link_names"] = 1
+
+                    client.chat_post_message(channel, event.text, **slack_api_params)
 
             except Exception as e:
                 logger.exception( "Could not handle slackout with key {} between {} and {}."


### PR DESCRIPTION
* Merges #341 (with [some tweaks](https://github.com/hangoutsbot/hangoutsbot/pull/341#issuecomment-132856172)) (5f910c1)
* Creates framework module: `exceptions` (de526ea) and `event` (5f910c1) - both were split from bot's main module
* Bugfix: Fix long-standing error with [reprocessor registration raising an error](https://github.com/hangoutsbot/hangoutsbot/commit/de526eae6ed365f878b887b4bb67fb071abc757e#diff-7877cb1d84780ee45580db79ff5a1478R37) on bot disconnection/reconnection (de526ea)
* **Slack** - Enhancement: Merged #342 and added additional code to enable/disable Slack API parameter `link_names` from `sinkConfig` (599b62e, [config instructions updated](https://github.com/hangoutsbot/hangoutsbot/wiki/Slack-Plugin#setting-up-the-sink-and-webhook))