### PR TITLE
Clean up warnings with BeautifulSoup

### DIFF
--- a/hangupsbot/plugins/image_memegenerator.py
+++ b/hangupsbot/plugins/image_memegenerator.py
@@ -22,7 +22,7 @@ def _retrieve(url, css_selector, attribute):
     logger.debug("_retrieve(): getting {}".format(url))
     html_request = yield from aiohttp.request('get', url)
     html = yield from html_request.read()
-    soup = BeautifulSoup(str(html, 'utf-8'))
+    soup = BeautifulSoup(str(html, 'utf-8'), 'html.parser')
     links = []
     for link in soup.select(css_selector):
         links.append(link.get(attribute))

--- a/hangupsbot/plugins/lookup.py
+++ b/hangupsbot/plugins/lookup.py
@@ -50,7 +50,7 @@ def lookup(bot, event, *args):
     # Adapted from http://stackoverflow.com/questions/23377533/python-beautifulsoup-parsing-table
     from bs4 import BeautifulSoup
 
-    soup = BeautifulSoup(str(html, 'utf-8'))
+    soup = BeautifulSoup(str(html, 'utf-8'), 'html.parser')
     table = soup.find('table', attrs={'class':table_class})
     table_body = table.find('tbody')
 


### PR DESCRIPTION
Now that logging and warnings are working well, we're seeing warnings :-)

/usr/local/lib/python3.4/site-packages/bs4/__init__.py:166: UserWarning: No parser was explicitly specified, so I'm using the best available HTML parser for this system ("html.parser"). This usually isn't a problem, but if you run this code on another system, or in a different virtual environment, it may use a different parser and behave differently.

To get rid of this warning, change this:

 BeautifulSoup([your markup])

to this:

 BeautifulSoup([your markup], "html.parser")



