### PR TITLE
slack-legacy: Add a way to sync per room

### DIFF
--- a/hangupsbot/config.json
+++ b/hangupsbot/config.json
@@ -43,7 +43,8 @@
     "port": 8085,
     "key": "SLACK_API_KEY",
     "channel": "#SLACK_CHANNEL_NAME",
-    "synced_conversations": ["CONV_ID_1", "CONV_ID_2"]
+    "synced_conversations": ["CONV_ID_1", "CONV_ID_2"],
+    "multi_hooks": false
     }
   ],
   "spreadsheet_enabled": false,

--- a/hangupsbot/plugins/slack.py
+++ b/hangupsbot/plugins/slack.py
@@ -179,6 +179,8 @@ def _handle_slackout(bot, event, command):
                 convlist = sinkConfig["synced_conversations"]
 
                 if event.conv_id in convlist:
+                    if sinkConfig["multi_hooks"]:
+                        channel = sinkConfig["channel"][convlist.index(event.conv_id)]
                     fullname = event.user.full_name
                     response = yield from bot._client.getentitybyid([event.user_id.chat_id])
                     try:


### PR DESCRIPTION
if you setup multi slack hooks you can sync every room seperate
Array (channel and synced_conversations) must have same lenght and order. 
Based  on current synced_conversations the right slack channel will be picked.

example:

   #development <-> UgwYjR0Q6ygVn7evyWR4AaABAQ
   #general <-> UgzBlVbTLVqV7PHWvPt4AaABAQ

current behavior:

   #development <- UgwYjR0Q6ygVn7evyWR4AaABAQ
    ----------------- ↘
   #general <-> UgzBlVbTLVqV7PHWvPt4AaABAQ

Config:
  "slack": [
    {
      ...
      "channel": ["#development", "#general"],
      ...
      "synced_conversations": [
      "UgwYjR0Q6ygVn7evyWR4AaABAQ",
      "UgzBlVbTLVqV7PHWvPt4AaABAQ"
      ],
      "multi_hooks": true
    }
  ],
