### PR TITLE
Fix initialise -> _initialise

### DIFF
--- a/hangupsbot/plugins/remind.py
+++ b/hangupsbot/plugins/remind.py
@@ -1,7 +1,7 @@
 import plugins
 import asyncio
 
-def initialise(bot):
+def _initialise(bot):
     plugins.register_user_command(["remindme","remindall"])
 
 def remindme(bot, event, dly, *args):


### PR DESCRIPTION
Currently, initialise shows up as a bot command because reminder did it wrong.