### PR TITLE
Warn nicely if python_dateutil is missing

### DIFF
--- a/hangupsbot/sinks/gitlab/simplepush.py
+++ b/hangupsbot/sinks/gitlab/simplepush.py
@@ -1,10 +1,15 @@
 import asyncio, json, logging
 
 from sinks.base_bot_request_handler import AsyncRequestHandler
-import dateutil.parser
-
 
 logger = logging.getLogger(__name__)
+
+try:
+    import dateutil.parser
+except ImportError:
+    logger.error("missing module python_dateutil: pip3 install python_dateutil")
+    raise
+
 
 
 class webhookReceiver(AsyncRequestHandler):


### PR DESCRIPTION
We need to parse an ISO-8601 date string. The recommended way to do this
is using dateutil, which might not be installed.

I'm reluctant to add dateutil to requirements.txt because it's currently only used
by the gitlab plugin.  Sadly, the plugin errors out in a very non-intuitive way which
causes lots of hair pulling if we don't have the import around a try/except.