### PR TITLE
Add Notice

### DIFF
--- a/hangupsbot/config.json
+++ b/hangupsbot/config.json
@@ -49,5 +49,6 @@
   "strict_botkeeper_check": false,
   "sync_rooms": [["CONV_ID_1", "CONV_ID_2"]],
   "syncing_enabled": false,
-  "watch_new_adds": false
+  "watch_new_adds": false,
+  "add_notice_message":"Hello, I am a new bot!"
 }

--- a/hangupsbot/plugins/addnotice.py
+++ b/hangupsbot/plugins/addnotice.py
@@ -1,0 +1,16 @@
+import asyncio
+import hangups
+import plugins
+
+def _initialise(bot):
+    plugins.register_handler(_send_notice_to_chat_when_added, type="membership")
+
+@asyncio.coroutine
+def _send_notice_to_chat_when_added(bot, event, command):
+    message=bot.get_config_option("add_notice_message")
+    bot_id = bot._user_list._self_user.id_
+    if event.conv_event.type_ == hangups.MembershipChangeType.JOIN:
+        if bot_id in event.conv_event.participant_ids:
+            # bot was part of the event
+            initiator_user_id = event.user_id.chat_id
+            yield from bot.coro_send_message(event.conv,message,context={ "parser": True })


### PR DESCRIPTION
When bot is added to a chat, it will send the message set in config to
the chat. Change add_notice_message to the message you wish to be sent, which can be HTML formatted.