### PR TITLE
Reworked the forecast plugin

### DIFF
--- a/hangupsbot/plugins/forecast.py
+++ b/hangupsbot/plugins/forecast.py
@@ -98,17 +98,20 @@ def _lookup_address(location):
     Retrieve the coordinates of the location from googles geocode api.
     Limit of 2,000 requests a day
     """
-    google_map_url = 'http://maps.googleapis.com/maps/api/geocode/json'
-    payload = {'address': location.replace(' ', '')}
-    r = requests.get(google_map_url, params=payload)
-
+     google_map_url = 'https://maps.googleapis.com/maps/api/geocode/json'
+    payload = {'address': location}
+    resp = requests.get(google_map_url, params=payload)
     try:
-        coords = r.json()['results'][0]['geometry']['location']
-    except ValueError as e:
-        logger.error("Forecast Error: {}".format(e))
-        coords = {}
-
-    return coords
+        resp.raise_for_status()
+        results = resp.json()['results'][0]
+        return {
+            'lat': results['geometry']['location']['lat'],
+            'lng': results['geometry']['location']['lng'],
+            'address': results['formatted_address']
+        }
+    except (IndexError, KeyError):
+        logger.error('unable to parse address return data: %d: %s', resp.status_code, resp.json())
+        return None
 
 def _lookup_weather(coords):
     """


### PR DESCRIPTION
- Changed the /bot forecast command to /bot weather referencing issue #499 
- Added the ability to set a default weather location for a hangout that when the weather or forecast command is called the bot will use the default if set.
- The weather command  show the temperature, conditions, feels like, wind speed and direction, humidity and pressure (if available) . Example:
  
    > It is currently: -9.90°C
    > Partly Cloudy
    > Feels Like: -15.19°C
    > Wind: 10.22 km/h from WSW
    > Humidity: 81%
    > Pressure: 101.97 kPa
- Added /bot forecast that show the next 24 hours and the next 7 day forecast (if available) #497 Example:

    > **Next 24 Hours**
    > Mostly cloudy throughout the day.
    > **Next 7 Days**
    > Mixed precipitation throughout the week, with temperatures rising to 9°C on Monday.

- The api call now returns the units for the location you are getting the weather information for, Canada is Celsius, America is ferinheight etc. The units to use are determined from the api call results