### PR TITLE
Configuration option to not require alias in one to one conversations with the bot

### DIFF
--- a/hangupsbot/handlers.py
+++ b/hangupsbot/handlers.py
@@ -167,7 +167,10 @@ class EventHandler:
 
         # check that a bot alias is used e.g. /bot
         if not event.text.split()[0].lower() in self.bot_command:
-            return
+            if self.bot.conversations.catalog[event.conv_id]["type"] == "ONE_TO_ONE" and self.bot.get_config_option('auto_alias_one_to_one'):
+                event.text = u" ".join((self.bot_command[0], event.text)) # Insert default alias if not already present
+            else:
+                return
 
         # Parse message
         event.text = event.text.replace(u'\xa0', u' ') # convert non-breaking space in Latin1 (ISO 8859-1)


### PR DESCRIPTION
When the configuration option _auto_alias_one_to_one_ is set to true, the bot will respond without needing to be addressed by /bot or other alias. This makes interaction with the bot in one to one conversations much more natural.
