### PR TITLE
Fix remindme command to actually send to 1 on1

### DIFF
--- a/hangupsbot/plugins/remind.py
+++ b/hangupsbot/plugins/remind.py
@@ -20,7 +20,7 @@ def remindme(bot, event, dly, *args):
         yield from bot.coro_send_message(event.conv, _("Private reminder for <b>{}</b> in {}m").format(event.user.full_name, dly))
         conv_1on1 = yield from bot.get_1to1(event.user.id_.chat_id)
         yield from asyncio.sleep(delayTime)
-        yield from bot.coro_send_message(event.conv, _("<b>Reminder:</b> " + " ".join(str(x) for x in args)))
+        yield from bot.coro_send_message(conv_1on1, _("<b>Reminder:</b> " + " ".join(str(x) for x in args)))
     except ValueError:
         yield from bot.coro_send_message(event.conv, _("Error creating reminder, invalid delay"))
 


### PR DESCRIPTION
Simple oversight in original that sent the reminder to the hangout where the command was given.  Now like it is notated the command will reply with the reminder in a private 1on1 hangout of the person that used the /bot remindme command