### PR TITLE
Added an "addhere" into the convtools plugin

### DIFF
--- a/hangupsbot/plugins/convtools.py
+++ b/hangupsbot/plugins/convtools.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 def _initialise(bot):
-    plugins.register_admin_command(["addme", "addusers", "createconversation", "refresh", "kick"])
+    plugins.register_admin_command(["addme", "addusers", "createconversation", "refresh", "kick", "addhere" ])
 
 
 @asyncio.coroutine
@@ -65,6 +65,21 @@ def addusers(bot, event, *args):
         added = yield from _batch_add_users(bot, target_conv, list_add)
     logger.info("addusers: {} added to {}".format(added, target_conv))
 
+def addhere(bot, event, *args):
+    """adds user(s) into the current chat
+    Usage: /bot addhere
+    <user id(s)>"""
+    list_add = []
+    target_conv = event.conv_id
+
+    for parameter in args:
+        list_add.append(parameter)
+
+    list_add = list(set(list_add))
+    added = 0
+    if len(list_add) > 0:
+        added = yield from _batch_add_users(bot, target_conv, list_add)
+    logger.info("addhere: {} added to {}".format(added, target_conv))
 
 def addme(bot, event, *args):
     """add yourself into a chat


### PR DESCRIPTION
Added an "addhere <user id(s)>" command into the convtools plugin, doing pretty much the same than "addusers <users id(s)>" but not allowing you to add anyone to another hangout than the current one. This command could be given access to more people than just an administrator.
#372
