### PR TITLE
Allow for HTTP (in addition to HTTPS) sync

### DIFF
--- a/hangupsbot/sinks/__init__.py
+++ b/hangupsbot/sinks/__init__.py
@@ -42,12 +42,8 @@ def start(bot):
                     logger.error("config.jsonrpc[{}].module must be a valid package name".format(itemNo))
                     continue
 
-                certfile = sinkConfig["certfile"]
-                if not certfile:
-                    logger.error("config.jsonrpc[{}].certfile must be configured".format(itemNo))
-                    continue
-
-                if not os.path.isfile(certfile):
+                certfile = sinkConfig.get("certfile")
+                if certfile and not os.path.isfile(certfile):
                     logger.error("config.jsonrpc[{}].certfile not available at {}".format(itemNo, certfile))
                     continue
 
@@ -108,10 +104,11 @@ def start_listening(bot=None, loop=None, name="", port=8000, certfile=None, webh
     try:
         httpd = HTTPServer((name, port), webhookReceiver)
 
-        httpd.socket = ssl.wrap_socket(
-          httpd.socket,
-          certfile=certfile,
-          server_side=True)
+        if certfile:
+            httpd.socket = ssl.wrap_socket(
+                httpd.socket,
+                certfile=certfile,
+                server_side=True)
 
         sa = httpd.socket.getsockname()
 
@@ -150,8 +147,11 @@ def aiohttp_start(bot, name, port, certfile, RequestHandlerClass, group, callbac
     handler = app.make_handler()
     RequestHandler.addroutes(app.router)
 
-    sslcontext = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
-    sslcontext.load_cert_chain(certfile)
+    if certfile:
+        sslcontext = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        sslcontext.load_cert_chain(certfile)
+    else:
+        sslcontext = None
 
     loop = asyncio.get_event_loop()
     server = loop.create_server(handler, name, port, ssl=sslcontext)


### PR DESCRIPTION
Many folks who use sinks are just opening up sockets on localhost, and we have a
convoluted process for generating self signed certificates to support this, and self signed certificates
don't necessarily verify properly, which can cause things like phantomjs to return errors.

Just simplify things and make HTTP optional.  If you don't specify a certfile on a sink, you get HTTP.