### PR TITLE
Fix for cleverbot chat command.

### DIFF
--- a/hangupsbot/plugins/cleverbot.py
+++ b/hangupsbot/plugins/cleverbot.py
@@ -219,10 +219,11 @@ class Cleverbot:
         parsed = [
             item.split('\r') for item in self.resp.decode('utf-8').split('\r\r\r\r\r\r')[:-1]
         ]
+
         parsed_dict = {
             'answer': parsed[0][0],
             'conversation_id': parsed[0][1],
-            'conversation_log_id': parsed[0][2],
+            # 'conversation_log_id': parsed[0][2],
         }
         try:
             parsed_dict['unknown'] = parsed[1][-1]


### PR DESCRIPTION
The response for the cleverbot api changed, the conversation log id is no longer in the response and the parser was throwing an error