### PR TITLE
dice rolls unbounded - could hang bot - issue #564

### DIFF
--- a/hangupsbot/plugins/chance.py
+++ b/hangupsbot/plugins/chance.py
@@ -39,7 +39,13 @@ def diceroll(bot, event, dice="1d6", *args):
         return
     if not n:
         n = 1
+    if isinstance(n, str) and len(n) > 2:
+        yield from bot.coro_send_message(event.conv, "I can't roll the dice this many times")
+        return
     n = int(n)
+    if len(s) > 4:
+        yield from bot.coro_send_message(event.conv, "Where can I find a {} sided dice?".format(s))
+        return
     s = int(s)
     if n < 1:
         yield from bot.coro_send_message(event.conv, "number of dice must be 1 or more")


### PR DESCRIPTION
chance plugin does not allow rolling a dice more than 99 times and rolling a dice with more than 9999 sides any more.

In other words you can only roll a 99d9999 for maximum possible sum