### PR TITLE
prevent upgrading telepot to keep it compatible with Python3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ spotipy
 slackclient >=0.16 # slackrtm (includes websockets)
 textblob
 python_dateutil # gitlab sink
-telepot >= 7.0 # telegram sync
+telepot == 7.1 # telegram sync, newer versions doesn't support Python3.4.1


### PR DESCRIPTION
Since telepot 8.0, async version of telepot library requires Python 3.5+ and since most of hangoutsbot instances are running on Python3.4 we need to prevent users from accidentally upgrading their telepot versions to 8.0+