### PR TITLE
Only trigger subscriptions that are surrounded by white-space

### DIFF
--- a/hangupsbot/plugins/subscribe.py
+++ b/hangupsbot/plugins/subscribe.py
@@ -39,7 +39,7 @@ def _handle_keyword(bot, event, command):
         try:
             if _internal.keywords[user.id_.chat_id] and not user.id_.chat_id in event.user.id_.chat_id:
                 for phrase in _internal.keywords[user.id_.chat_id]:
-                    regexphrase = "\\b" + phrase + "\\b"
+                    regexphrase = "(^|\s)" + phrase + "(\s|$)"
                     if re.search(regexphrase, event.text, re.IGNORECASE):
                         yield from _send_notification(bot, event, phrase, user)
         except KeyError:


### PR DESCRIPTION
Right now you get two notifications if you subscribe to your name using /bot subscribe and someone mentions you using @-mentions. Keyword subscriptions should only be triggered when the keyword is surrounded by white-space or at the beginning or end of the message. Simply checking for word boundaries is not enough, since @ is also a word boundary.