### PR TITLE
Fix trigger on bot's own message.

### DIFF
--- a/hangupsbot/plugins/subscribe.py
+++ b/hangupsbot/plugins/subscribe.py
@@ -21,6 +21,8 @@ def _initialise():
 
 def _handle_keyword(bot, event, command):
     """handle keyword"""
+    if event.user.is_self:
+        return
 
     _populate_keywords(bot, event)
 


### PR DESCRIPTION
When messages come in via API, subscribed keywords get triggered anyway.
This fix checks whether the message comes from the bot itself and ignores it then.