### PR TITLE
[Issue #597] Prevent @all botwars

### DIFF
--- a/hangupsbot/plugins/mentions.py
+++ b/hangupsbot/plugins/mentions.py
@@ -165,12 +165,12 @@ def mention(bot, event, *args):
                     if conv_1on1_initiator:
                         yield from bot.coro_send_message(
                             conv_1on1_initiator,
-                            _("You are not allowed to use @all in <b>{}</b>").format(
+                            _("You are not allowed to mention all usesrs in <b>{}</b>").format(
                                 conversation_name))
                     if noisy_mention_test or bot.get_config_suboption(event.conv_id, 'mentionerrors'):
                         yield from bot.coro_send_message(
                             event.conv,
-                            _("<b>{}</b> blocked from using <i>@all</i>").format(
+                            _("<b>{}</b> blocked from mentioning all users").format(
                                 event.user.full_name))
                     return
                 else:


### PR DESCRIPTION
The great hangout spamming of 2016-07-01 (Come to http://birmingham.willbe.blue/ ) resulted in botlooping because of the use of @all in the denial messages.
This is picked up by any other bots in the hangout and then treated as a mention, and so on ad infinitum.

Changes to the wording of the error message should prevent this in future.