### PR TITLE
Allow hashtags subscriptions

### DIFF
--- a/hangupsbot/plugins/subscribe.py
+++ b/hangupsbot/plugins/subscribe.py
@@ -41,7 +41,7 @@ def _handle_keyword(bot, event, command):
         try:
             if _internal.keywords[user.id_.chat_id] and not user.id_.chat_id in event.user.id_.chat_id:
                 for phrase in _internal.keywords[user.id_.chat_id]:
-                    regexphrase = "(^|\s)" + phrase + "(\s|$)"
+                    regexphrase = "(^| )" + phrase + "( |$)"
                     if re.search(regexphrase, event.text, re.IGNORECASE):
                         yield from _send_notification(bot, event, phrase, user)
         except KeyError:


### PR DESCRIPTION
This modification allows you to subscribe hashtags

`regexphrase = "(^|\s)" + phrase + "(\s|$)"`
to:
`regexphrase = "(^| )" + phrase + "( |$)"`
