### PR TITLE
global and channel tag autoreplies, image autoreplies

### DIFF
--- a/hangupsbot/plugins/autoreply.py
+++ b/hangupsbot/plugins/autoreply.py
@@ -22,7 +22,7 @@ def _handle_autoreply(bot, event, command):
         return
 
     if "autoreplies-disable" in bot.tags.useractive(event.user_id.chat_id, event.conv.id_):
-        # logger.debug("explicitly disabled by tag for {} {}".format(event.user_id.chat_id, event.conv.id_))
+        logger.debug("explicitly disabled by tag for {} {}".format(event.user_id.chat_id, event.conv.id_))
         return
 
     """Handle autoreplies to keywords in messages"""
@@ -64,13 +64,13 @@ def _handle_autoreply(bot, event, command):
             if isinstance(kwds, list):
                 for kw in kwds:
                     if _words_in_text(kw, event.text) or kw == "*":
-                        # logger.info("matched chat: {}".format(kw))
+                        logger.info("matched chat: {}".format(kw))
                         yield from send_reply(bot, event, message)
                         r = True
                         break
 
             elif event_type == kwds:
-                # logger.info("matched event: {}".format(kwds))
+                logger.info("matched event: {}".format(kwds))
                 yield from send_reply(bot, event, message)
                 r = True
 
@@ -85,13 +85,13 @@ def _handle_autoreply(bot, event, command):
             if isinstance(kwds, list):
                 for kw in kwds:
                     if _words_in_text(kw, event.text) or kw == "*":
-                        # logger.info("matched chat: {}".format(kw))
+                        logger.info("matched chat: {}".format(kw))
                         yield from send_reply(bot, event, message)
                         r = True
                         break
 
             elif event_type == kwds:
-                # logger.info("matched event: {}".format(kwds))
+                logger.info("matched event: {}".format(kwds))
                 yield from send_reply(bot, event, message)
                 r = True
 
@@ -106,12 +106,12 @@ def _handle_autoreply(bot, event, command):
             if isinstance(kwds, list):
                 for kw in kwds:
                     if _words_in_text(kw, event.text) or kw == "*":
-                        # logger.info("matched chat: {}".format(kw))
+                        logger.info("matched chat: {}".format(kw))
                         yield from send_reply(bot, event, message)
                         break
 
             elif event_type == kwds:
-                # logger.info("matched event: {}".format(kwds))
+                logger.info("matched event: {}".format(kwds))
                 yield from send_reply(bot, event, message)
 
 
@@ -151,10 +151,6 @@ def send_reply(bot, event, message):
 
     else:
         envelopes.append((event.conv, message.format(**values)))
-
-    # check with if, not elif, to allow one_to_one images
-    # message is changed above, so this works in all cases
-
 
     for send in envelopes:
         if message.startswith("BOTIMAGE:"):


### PR DESCRIPTION
I added some functionality to autoreplies with this commit.
### Global and per-tag autoreplies

The current version of autoreplies supports global triggers, but the global ones are ignored if a conversation has its own triggers configured. This implementation sets a new type of global autoreply that works in any conversation whether that conversation has its own config or not. `autoreplies_enabled` is respected, so a global reply will not be sent to a conversation with them disabled. They are specified by creating a conversation in the normal way in `config.json`, but using the conversation ID `GLOBAL`. The current functionality is still supported; the code only looks for the `GLOBAL` conversation ID.

Conversation tags are also supported. Tag any conversations in the normal way, then create a conversation in `config.json` with the ID `TAG:tagname`. The autoreply will work in any conversations with the given tag.

Autoreplies are prioritized **per-conversation**, then **per-tag**, then **global**. If the same trigger exists in both the conversation-specific list and the global list, for example, then the conversation-specific autoreply will be sent and the global one is ignored.
### Image autoreplies

The bot can send images as autoreplies. If a reply starts with `BOTIMAGE:`, the bot treats the rest of the message as the path to an image. If the path starts with `http`, the path is treated as a URL and the bot will attempt to fetch the image from that URL. If not, a local path is used relative to the top-level config option `autoreply_images_local_path`. All normal image types are supported, including animated .gifs.
