### PR TITLE
Add helper environment variables to spawned processes

### DIFF
--- a/hangupsbot/plugins/spawn.py
+++ b/hangupsbot/plugins/spawn.py
@@ -57,6 +57,9 @@ which will, of course, send back `/etc/passwd`.
 You're responsible for sanitizing any arguments passed on to the
 program, if `allow_args` is true. Writing your own small shell
 script to do so may be your best option.
+
+The environment variables from this program are passed along to
+the subprocess, along with additional helpers (see code below).
 """
 
 import os
@@ -104,7 +107,18 @@ def _spawn(bot, event, *args):
 
     executable = tuple(executable)
     logger.info("%s executing: %s", event.user.full_name, executable)
-    proc = yield from asyncio.create_subprocess_exec(*executable, stdout=PIPE, stderr=PIPE)
+
+    environment = {
+        'HANGOUT_USER_CHATID': event.user_id.chat_id,
+        'HANGOUT_USER_FULLNAME': event.user.full_name,
+        'HANGOUT_CONV_ID':  event.conv_id,
+        'HANGOUT_CONV_TAGS': ','.join(bot.tags.useractive(event.user_id.chat_id,
+                                                          event.conv_id))
+    }
+    environment.update(dict(os.environ))
+
+    proc = yield from asyncio.create_subprocess_exec(*executable, stdout=PIPE, stderr=PIPE,
+        env=environment)
 
     (stdout_data, stderr_data) = yield from proc.communicate()
     stdout_str = stdout_data.decode().rstrip()


### PR DESCRIPTION
Add environment variables to allow spawned programs to check authorization and have nice
helpers...

```
HANGOUT_USER_CHATID=1089090278230xxxxxxxx
HANGOUT_USER_FULLNAME=John Doe
HANGOUT_CONV_ID=UgwVk3ytehRTIoEH_xxxxxABAQ
HANGOUT_CONV_TAGS=foo-autoexpand
```
