### PR TITLE
Add support for Cross-Origin Resource Sharing

### DIFF
--- a/hangupsbot/plugins/api.py
+++ b/hangupsbot/plugins/api.py
@@ -78,9 +78,23 @@ def _start_api(bot):
 
 class APIRequestHandler(AsyncRequestHandler):
     def addroutes(self, router):
+        router.add_route("OPTIONS", "/", self.adapter_do_OPTIONS)
         router.add_route("POST", "/", self.adapter_do_POST)
         router.add_route('GET', '/{api_key}/{id}/{message:.*?}', self.adapter_do_GET)
 
+
+    @asyncio.coroutine
+    def adapter_do_OPTIONS(self, request):
+        origin = request.headers["Origin"]
+
+        # TODO make allowed origins configureable?
+        if False and origin not in ():
+            raise HTTPForbidden()
+
+        return web.Response(headers={
+            "Access-Control-Allow-Origin": origin,
+            "Access-Control-Allow-Headers": "content-type",
+        })
 
     @asyncio.coroutine
     def adapter_do_GET(self, request):

--- a/hangupsbot/plugins/api.py
+++ b/hangupsbot/plugins/api.py
@@ -87,13 +87,23 @@ class APIRequestHandler(AsyncRequestHandler):
     def adapter_do_OPTIONS(self, request):
         origin = request.headers["Origin"]
 
-        # TODO make allowed origins configureable?
-        if False and origin not in ():
+        allowed_origins = self._bot.get_config_option("api_origins")
+        if allowed_origins is None:
+            raise HTTPForbidden()
+
+        if "*" == allowed_origins or "*" in allowed_origins:
+            return web.Response(headers={
+                "Access-Control-Allow-Origin": origin,
+                "Access-Control-Allow-Headers": "content-type",
+            })
+
+        if not origin in allowed_origins:
             raise HTTPForbidden()
 
         return web.Response(headers={
             "Access-Control-Allow-Origin": origin,
             "Access-Control-Allow-Headers": "content-type",
+            "Vary": "Origin",
         })
 
     @asyncio.coroutine


### PR DESCRIPTION
This adds support for [CORS](https://en.wikipedia.org/wiki/Cross-origin_resource_sharing) to allow the API to be used from web pages across domains. By removing `False and` and adding a list of valid origins in line 91, this may be restricted to certain hosts. This could maybe converted to a config setting?
