### PR TITLE
Add tldr to PM functionality, update 'clear' command to require parameter, enable tldr between synced hangouts.

### DIFF
--- a/hangupsbot/plugins/tldr.py
+++ b/hangupsbot/plugins/tldr.py
@@ -1,4 +1,3 @@
-import hangups
 import time
 import plugins
 
@@ -23,14 +22,12 @@ def tldrecho(bot, event, p_tldr_echo=None):
     
     # If no tldr_echo setting specified, then the tldr_echo set for this hangout has been cleared.
     if p_tldr_echo is None:
-        segments = [hangups.ChatMessageSegment('TLDR echo setting for this hangout has been cleared', is_bold=True)]
+        message = '<b>TLDR echo setting for this hangout has been cleared.</b>'
     else:
-        # Get the current tldr_echo setting.
-        segments = [hangups.ChatMessageSegment('TLDR echo for this hangout is:', is_bold=True),
-                    hangups.ChatMessageSegment('\n', hangups.SegmentType.LINE_BREAK),
-                    hangups.ChatMessageSegment(p_tldr_echo)]
+        # echo the current tldr_echo setting.
+        message = '<b>TLDR echo setting for this hangout TLDR echo for this hangout is:</b><br />{}'.format(p_tldr_echo)
     
-    yield from bot.coro_send_message(event.conv_id, segments)
+    yield from bot.coro_send_message(event.conv_id, message)
 
 
 def tldr(bot, event, *args):

--- a/hangupsbot/plugins/tldr.py
+++ b/hangupsbot/plugins/tldr.py
@@ -10,7 +10,7 @@ def _initialise(bot):
 
 
 def tldrecho(bot, event, p_tldr_echo=None):
-    """<br/>/bot <i><b>tldrecho</b> <group/PM></i><br/>Defines whether the full tldr is echoed to a PM or into the main chat.<br/><br/>e.g. /bot tldrecho PM"""
+    """<br/>[botalias] <i><b>tldrecho</b> <group/PM></i><br/>Defines whether the full tldr is echoed to a PM or into the main chat.<br /><u>Usage</u><br />[botalias] <i><b>tldrecho</b> PM</i>"""
 
     # If no memory entry exists, create it.
     if not bot.memory.exists(['conversations']):

--- a/hangupsbot/plugins/tldr.py
+++ b/hangupsbot/plugins/tldr.py
@@ -34,7 +34,7 @@ def tldrecho(bot, event, p_tldr_echo=None):
 
 
 def tldr(bot, event, *args):
-    """<br/>/bot <i><b>tldr</b> <message></i><br/>Adds a short message to a list saved for the conversation.<br/>All TLDRs can be retrieved using: /bot <i><b>tldr</b></i>, single tldr using: /bot <i><b>tldr</b> <number></i><br/>All TLDR entries can be deleted using: /bot <i><b>tldr clear</b></i>, single tldr entries using: /bot <i><b>tldr clear</b> <number></i><br/>Single TLDRs can be edited using /bot <i><b>tldr edit</b> <number> <new message></i><br/>"""
+    """<br/>/bot <i><b>tldr</b> <message></i><br/>Adds a short message to a list saved for the conversation.<br/>/bot <i><b>tldr</b></i><br/>Retrieve all TLDR entries.<br/>/bot <i><b>tldr</b> <number></i><br/>Retrieve an individual TLDR entry.<br/>/bot <i><b>tldr clear all</b></i><br/>Clear all TLDR entries.<br/>/bot <i><b>tldr clear</b> <number></i><br/>Clear an individual TLDR entry.<br/>/bot <i><b>tldr edit</b> <number> <new message></i><br/>Edit an individual TLDR entry."""
 
     ## Retrieve the current tldr echo status for the hangout.
     # If no memory entry exists, create it.
@@ -47,7 +47,7 @@ def tldr(bot, event, *args):
     # If nothing set, then set the bot default as False.
 
     if not bot.memory.exists(['conversations',event.conv_id,'tldr_echo']):
-        if not bot.get_config_option('tldr_echo'):
+        if not bot.get_config_option('tldr_echo'):/ops 
             bot.config.set_by_path(["tldr_echo"], 'group')
             bot.config.save()
     
@@ -117,7 +117,7 @@ def tldr_base(bot, conv_id, parameters):
                                                              _time_ago(float(timestamp))))
 
         if len(html) == 0:
-            html.append(_("TL;DR not found"))
+            html.append(_("TL;DR not found."))
             display = False
         else:
             html.insert(0, _("<b>TL;DR ({} stored):</b>").format(len(conv_tldr)))
@@ -126,19 +126,21 @@ def tldr_base(bot, conv_id, parameters):
         return message, display
 
     if parameters[0] == "clear":
-        if len(parameters) == 2 and parameters[1].isdigit():
-            sorted_keys = sorted(list(conv_tldr.keys()), key=float)
-            key_index = int(parameters[1]) - 1
-            if key_index < 0 or key_index >= len(sorted_keys):
-                message = _("TL;DR #{} not found").format(parameters[1])
-            else:
-                popped_tldr = conv_tldr.pop(sorted_keys[key_index])
-                bot.memory.set_by_path(['tldr', conv_id], conv_tldr)
-                message = _('TL;DR #{} removed - "{}"').format(parameters[1], popped_tldr)
+        if len(parameters) == 2:
+            if  parameters[1].isdigit():
+                sorted_keys = sorted(list(conv_tldr.keys()), key=float)
+                key_index = int(parameters[1]) - 1
+                if key_index < 0 or key_index >= len(sorted_keys):
+                    message = _("TL;DR #{} not found").format(parameters[1])
+                else:
+                    popped_tldr = conv_tldr.pop(sorted_keys[key_index])
+                    bot.memory.set_by_path(['tldr', conv_id], conv_tldr)
+                    message = _('TL;DR #{} removed - "{}"').format(parameters[1], popped_tldr)
+            elif parameters[1] == "all":
+                bot.memory.set_by_path(['tldr', conv_id], {})
+                message = _("All TL;DRs cleared.")
         else:
-            bot.memory.set_by_path(['tldr', conv_id], {})
-            message = _("All TL;DRs cleared")
-
+            message = _("Nothing specified to clear.")
         return message, display
 
     elif parameters[0] == "edit":
@@ -154,7 +156,7 @@ def tldr_base(bot, conv_id, parameters):
                 bot.memory.set_by_path(['tldr', conv_id], conv_tldr)
                 message = _('TL;DR #{} edited - "{}" -> "{}"').format(parameters[1], edited_tldr, tldr)
         else:
-            message = _('Unknown Command at "tldr edit"')
+            message = _('Unknown Command at "tldr edit."')
 
         return message, display
 
@@ -164,7 +166,7 @@ def tldr_base(bot, conv_id, parameters):
             # Add message to list
             conv_tldr[str(time.time())] = tldr
             bot.memory.set_by_path(['tldr', conv_id], conv_tldr)
-            message = _('<em>{}</em> added to TL;DR. Count: {}').format(tldr, len(conv_tldr))
+            message = _('<em>{}</em> added to TL;DR. Count: {}.').format(tldr, len(conv_tldr))
 
             return message, display
 

--- a/hangupsbot/plugins/tldr.py
+++ b/hangupsbot/plugins/tldr.py
@@ -47,7 +47,7 @@ def tldr(bot, event, *args):
     # If nothing set, then set the bot default as False.
 
     if not bot.memory.exists(['conversations',event.conv_id,'tldr_echo']):
-        if not bot.get_config_option('tldr_echo'):/ops 
+        if not bot.get_config_option('tldr_echo'):
             bot.config.set_by_path(["tldr_echo"], 'group')
             bot.config.save()
     


### PR DESCRIPTION
Add code to permit sending the tldr in a PM to a user when requested.
Individually requested tldr entries will still be echoed to the group chat.
Creates a global config entry defaulting to 'group' when the plugin is first called.
/bot tldrpm alters the behaviour on a per-chat basis.
