### PR TITLE
Added sync for stickers to telesync

### DIFF
--- a/hangupsbot/plugins/telesync/__init__.py
+++ b/hangupsbot/plugins/telesync/__init__.py
@@ -270,7 +270,7 @@ def tg_on_sticker(tg_bot, tg_chat_id, msg):
         text = "Uploading sticker from <b>{uname}</b> in <b>{gname}</b>...".format(
             uname=tg_util_sync_get_user_name(msg),
             gname=tg_util_get_group_name(msg))
-        tg_bot.ho_bot.coro_send_message(conversation=ho_conv_id, message=text)
+        yield from tg_bot.ho_bot.coro_send_message(conversation=ho_conv_id, message=text)
 
         file_dir = os.path.dirname(photo_path)
         if not os.path.exists(file_dir):

--- a/hangupsbot/plugins/telesync/__init__.py
+++ b/hangupsbot/plugins/telesync/__init__.py
@@ -164,8 +164,8 @@ class TelegramBot(telepot.async.Bot):
                     yield from self.onPhotoCallback(self, chat_id, msg)
 
                 elif content_type == 'sticker':
-                    if 'sync_sticker' in tg_bot.ho_bot.config.get_by_path(['telesync']):
-                        if tg_bot.ho_bot.config.get_by_path(['telesync'])['sync_sticker']:
+                    if 'enable_sticker_sync' in tg_bot.ho_bot.config.get_by_path(['telesync']):
+                        if tg_bot.ho_bot.config.get_by_path(['telesync'])['enable_sticker_sync']:
                             yield from self.onStickerCallback(self, chat_id, msg)
 
             elif flavor == "inline_query":  # inline query e.g. "@gif cute panda"


### PR DESCRIPTION
Added sync for stickers from Telegram to Hangouts in the telesync plugin.
Sync has to be enabled in conf.json with:
`"enable_sticker_sync":true`
Otherwise it will default to false.