### PR TITLE
Added Profile synchronisation to telesync plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ aiohttp
 *.jpg
 
 venv
+
+.idea/


### PR DESCRIPTION
Allows Hangouts bot to use g+ user name in Hangouts instead of the Telegram user name.
Users can set up sync in private chats with TG and HO bot.

In Telegram use /syncprofile and copy the answered command into pHO with the bot.
To remove sync use /unsyncprofile in Telegram