### PR TITLE
add routes should called before making the app handler

### DIFF
--- a/hangupsbot/sinks/__init__.py
+++ b/hangupsbot/sinks/__init__.py
@@ -143,9 +143,9 @@ def aiohttp_start(bot, name, port, certfile, RequestHandlerClass, group, callbac
     RequestHandler = RequestHandlerClass(bot)
 
     app = web.Application()
+    RequestHandler.addroutes(app.router)
 
     handler = app.make_handler()
-    RequestHandler.addroutes(app.router)
 
     if certfile:
         sslcontext = ssl.SSLContext(ssl.PROTOCOL_SSLv23)


### PR DESCRIPTION
Fixes error in aiohttp about adding routes to a frozen router