### PR TITLE
Use link instead of note for @mentions

### DIFF
--- a/hangupsbot/plugins/mentions.py
+++ b/hangupsbot/plugins/mentions.py
@@ -303,11 +303,12 @@ def mention(bot, event, *args):
                         success = False
                         try:
                             pb = PushBullet(pushbullet_config["api"])
-                            push = pb.push_note(
-                                _("{} mentioned you in {}").format(
+                            push = pb.push_link(
+                                title=("{} mentioned you in {}").format(
                                         source_name,
                                         conversation_name),
-                                    event.text)
+                                    body=event.text,
+                                    url='https://hangouts.google.com/chat{}'.format(event.conv.id_))
                             if isinstance(push, tuple):
                                 # backward-compatibility for pushbullet library < 0.8.0
                                 success = push[0]

--- a/hangupsbot/plugins/mentions.py
+++ b/hangupsbot/plugins/mentions.py
@@ -308,7 +308,7 @@ def mention(bot, event, *args):
                                         source_name,
                                         conversation_name),
                                     body=event.text,
-                                    url='https://hangouts.google.com/chat{}'.format(event.conv.id_))
+                                    url='https://hangouts.google.com/chat/{}'.format(event.conv.id_))
                             if isinstance(push, tuple):
                                 # backward-compatibility for pushbullet library < 0.8.0
                                 success = push[0]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 git+https://github.com/hangoutsbot/hangups.git
 appdirs
 asyncio
-aiohttp >= 0.21.2
+aiohttp>=1.0,<1.1
 jsonrpclib-pelix
 
 # PLUGIN DEPENDENCIES #


### PR DESCRIPTION
This updates [mentions.py](hangoutsbot/plugins/mentions.py) to use links instead of notes when sending @mentions via Pushbullet. This allows users to open the relevant Hangout directly from the notification.