### PR TITLE
Add regex_match property to conversation event

### DIFF
--- a/hangupsbot/plugins/autoreply.py
+++ b/hangupsbot/plugins/autoreply.py
@@ -50,8 +50,10 @@ def _handle_autoreply(bot, event, command):
 
             if isinstance(kwds, list):
                 for kw in kwds:
-                    if _words_in_text(kw, event.text) or kw == "*":
+                    matched = _words_in_text(kw, event.text)
+                    if matched or kw == "*":
                         logger.info("matched chat: {}".format(kw))
+                        event.regex_match = matched
                         yield from send_reply(bot, event, message)
                         break
 
@@ -112,7 +114,9 @@ def _words_in_text(word, text):
 
     regexword = "(?<!\w)" + word + "(?!\w)"
 
-    return True if re.search(regexword, text, re.IGNORECASE) else False
+    match = re.search(regexword, text, re.IGNORECASE)
+
+    return match.group(0) if match else False
 
 
 def autoreply(bot, event, cmd=None, *args):


### PR DESCRIPTION
Ref #674 

Forgive any semantic errors here - I'll gladly fix them. I have almost 0 Python knowledge 😅 

Add a `regex_match` property to conversation events in the case of a regex-based autoreply that contains the value matched in the first match group.