### PR TITLE
Google Calendar plugin

### DIFF
--- a/hangupsbot/plugins/gcal.py
+++ b/hangupsbot/plugins/gcal.py
@@ -1,0 +1,114 @@
+"""
+Integration with Google Calendar.
+
+To generate the client secrets file::
+
+    $ python -m plugins.gcal client_id client_secret path/to/secrets.json
+
+Then set config key `gcal.secrets` to the path of the newly generated file.
+"""
+
+
+from argparse import ArgumentParser
+from datetime import date, datetime
+from httplib2 import Http
+import logging
+
+from googleapiclient.discovery import build
+from oauth2client.client import OAuth2WebServerFlow
+from oauth2client.file import Storage
+
+import plugins
+
+
+DATE = "%Y-%m-%d"
+DATETIME = "%Y-%m-%dT%H:%M:%SZ"
+
+logger = logging.getLogger(__name__)
+config = None
+service = None
+
+
+def _initialise(bot):
+    global config, service
+    config = bot.get_config_option("gcal")
+    if not config or "secrets" not in config:
+        logger.error("gcal: missing path to secrets file")
+        return
+    store = Storage(config["secrets"])
+    http = store.get().authorize(Http())
+    service = build("calendar", "v3", http=http)
+    plugins.register_user_command(["calendar"])
+
+def pretty_date(d):
+    now = datetime.utcnow()
+    if isinstance(d, datetime):
+        diff = d - now
+        if diff.seconds < 0:
+            return "now"
+        elif diff.days == 0:
+            if diff.seconds < 60 * 60:
+                return "in {} minutes".format(diff.seconds // 60) # in 10 minutes
+            else:
+                return "in {} hours".format(diff.seconds // (60 * 60)) # in 3 hours
+        elif diff.days == 1:
+            return "tomorrow {}".format(d.strftime("%H:%M")) # tomorrow 11:30
+        elif diff.days < 7:
+            return d.strftime("%A %H:%M") # Monday 11:30
+        else:
+            return d.strftime("%d/%m/%Y %H:%M") # 19/12/2016 11:30
+    elif isinstance(d, date):
+        now = now.date()
+        diff = d - now
+        if diff.days == 0:
+            return "today"
+        elif diff.days == 1:
+            return "tomorrow"
+        elif diff.days < 7:
+            return d.strftime("%A") # Monday
+        else:
+            return d.strftime("%d/%m/%Y") # 19/12/2016
+
+def calendar(bot, event, *args):
+    msg = None
+    if not args:
+        args = ["list"]
+    if args[0] == "help":
+        msg = "Usage:\n" \
+              "- list events: `/bot calendar list`"
+    elif args[0] == "list":
+        resp = service.events().list(calendarId=config.get("id", "primary"),
+                                     timeMin=date.today().strftime(DATETIME)).execute()
+        if not resp["items"]:
+            msg = "No upcoming events."
+        else:
+            msg = "Upcoming events:"
+            for item in resp["items"]:
+                if "dateTime" in item["start"]:
+                    start = datetime.strptime(item["start"]["dateTime"], DATETIME)
+                elif "date" in item["start"]:
+                    start = datetime.strptime(item["start"]["date"], DATE).date()
+                msg += "\n<b>{}</b> -- {}".format(item["summary"], pretty_date(start))
+                if "description" in item:
+                    msg += "\n<i>{}</i>".format(item["description"])
+                if "location" in item:
+                    msg += "\n{}".format(item["location"])
+    else:
+        msg = "Unknown command, try `help` for a list."
+    if msg:
+        yield from bot.coro_send_message(event.conv_id, msg)
+
+
+if __name__ == "__main__":
+
+    from oauth2client import tools
+
+    parser = ArgumentParser(parents=[tools.argparser])
+    parser.add_argument("client_id", help="public key for Google APIs")
+    parser.add_argument("client_secret", help="secret key for Google APIs")
+    parser.add_argument("path", help="output file for the generated secrets file")
+    args = parser.parse_args()
+
+    flow = OAuth2WebServerFlow(client_id=args.client_id, client_secret=args.client_secret,
+                               scope="https://www.googleapis.com/auth/calendar")
+    tools.run_flow(flow, Storage(args.path), args)

--- a/hangupsbot/plugins/gcal.py
+++ b/hangupsbot/plugins/gcal.py
@@ -52,9 +52,11 @@ def pretty_date(d):
             return "now"
         elif diff.days == 0:
             if diff.seconds < 60 * 60:
-                return "in {} minutes".format(diff.seconds // 60) # in 10 minutes
+                mins = diff.seconds // 60
+                return "in {} minute{}".format(mins, "" if mins == 1 else "s") # in 10 minutes
             else:
-                return "in {} hours".format(diff.seconds // (60 * 60)) # in 3 hours
+                hrs = diff.seconds // (60 * 60)
+                return "in {} hour{}".format(hrs, "" if hrs == 1 else "s") # in 3 hours
         elif diff.days == 1:
             return "tomorrow {}".format(d.strftime("%H:%M")) # tomorrow 11:30
         elif diff.days < 7:
@@ -75,16 +77,17 @@ def pretty_date(d):
 
 def cal_list():
     resp = service.events().list(calendarId=config.get("id", "primary"),
-                                 timeMin=date.today().strftime(DATETIME)).execute()
+                                 timeMin=date.today().strftime(DATETIME),
+                                 singleEvents=True, orderBy="startTime").execute()
     if not resp["items"]:
         return "No upcoming events."
     msg = "Upcoming events:"
-    for item in resp["items"]:
+    for pos, item in enumerate(resp["items"]):
         if "dateTime" in item["start"]:
             start = datetime.strptime(item["start"]["dateTime"], DATETIME)
         elif "date" in item["start"]:
             start = datetime.strptime(item["start"]["date"], DATE).date()
-        msg += "\n<b>{}</b> -- {}".format(item["summary"], pretty_date(start))
+        msg += "\n{}. <b>{}</b> -- {}".format(pos + 1, item["summary"], pretty_date(start))
         if "description" in item:
             msg += "\n<i>{}</i>".format(item["description"])
         if "location" in item:

--- a/hangupsbot/plugins/gcal.py
+++ b/hangupsbot/plugins/gcal.py
@@ -96,6 +96,19 @@ def cal_list(cal):
             msg += "\n{}".format(item["location"])
     return msg
 
+def cal_show(cal, pos):
+    item = cache[cal][pos]
+    if "dateTime" in item["start"]:
+        start = datetime.strptime(item["start"]["dateTime"], DATETIME)
+    elif "date" in item["start"]:
+        start = datetime.strptime(item["start"]["date"], DATE).date()
+    msg = "<b>{}</b> -- {}".format(item["summary"], pretty_date(start))
+    if "description" in item:
+        msg += "\n<i>{}</i>".format(item["description"])
+    if "location" in item:
+        msg += "\n{}".format(item["location"])
+    return msg
+
 def cal_add(cal, what, when, where=None, desc=None):
     data = {"summary": what, "start": {}}
     try:
@@ -155,11 +168,24 @@ def calendar(bot, event, *args):
     if args[0] == "help":
         msg = "Usage:\n" \
               "- list events: `/bot calendar list`\n" \
+              "- show a single event: `/bot calendar show <pos>`\n" \
               "- add a new event: `/bot calendar add \"<what>\" \"<when>\" [at \"where\"] [\"description\"]`" \
               "- update an event: `/bot calendar update <pos> <title/date/place/description> \"<update>\" [...]`" \
               "- remove an event: `/bot calendar remove <pos>`"
     elif args[0] == "list":
         msg = cal_list(cal)
+    elif args[0] == "show":
+        if not cal in cache:
+            msg = "Need to refresh the list of events first, try `/bot calendar list`."
+        else:
+            try:
+                pos = int(args[1]) - 1
+            except ValueError:
+                msg = "Use the number given in the event list to remove events."
+            except IndexError:
+                msg = "Don't know about that event.  See `/bot calendar list` for current events."
+            else:
+                msg = cal_show(cal, pos)
     elif args[0] == "add":
         if len(args) < 3 or not args[1] or not args[2]:
             msg = "Need to specify both what and when."


### PR DESCRIPTION
I've started playing with the idea of a plugin that integrates with Google Calendar (#298).  It's a bit rough around the edges at the moment, but thought it might be a good idea to check in for the hangoutsbot side of things.

Currently it supports listing/adding/updating/removing events, and calendars can be global or per-hangout.  Dependencies are [oauth2client](https://oauth2client.readthedocs.io) and the [Google API Client](https://developers.google.com/api-client-library/python/).  Date formats are all `dd/mm/yyyy` for now, but of course would be nice to make that configurable or more flexible.

Authentication is a bit of a pain -- you need to generate an access token (oauth2client's client_secrets.json) first, so I've set the plugin up to run the OAuth flow if run directly (`python -m plugins.gcal`).  I'm happy to document things on the wiki if this does become an official part of hangoutsbot.  🙂

Some bonus questions:
* Is there a standard/nice way to handle complex command parameters?  Currently I'm disregarding `*args` in favour of `shlex.split(event.text)` to preserve quoting for multi-word parameters...
* How best to separate user and admin sub-commands?  Something that can be done with tags, or should I just have two separate commands?