### PR TITLE
Use botalias in help text

### DIFF
--- a/hangupsbot/commands/basic.py
+++ b/hangupsbot/commands/basic.py
@@ -40,6 +40,7 @@ def help(bot, event, cmd=None, *args):
                                 '<b><pre>{}</pre></b><br />').format( help_chat_id,
                                                                       help_conv_id ))
 
+        help_lines.append('[botalias] <i><b>help</b> <command></i><br/>Show more info about a command.<br />')
         if len(commands_nonadmin) > 0:
             help_lines.append(_('<b>User commands:</b>'))
             help_lines.append(', '.join(sorted(commands_nonadmin)))
@@ -62,6 +63,8 @@ def help(bot, event, cmd=None, *args):
             return
 
         help_lines.append("<b>{}</b>: {}".format(command_fn.__name__, command_fn.__doc__))
+        
+    help_lines = [lines.replace('[botalias]', bot._handlers.bot_command[0]) for lines in help_lines]
 
     yield from bot.coro_send_to_user_and_conversation(
         event.user.id_.chat_id,


### PR DESCRIPTION
Rather than hard coding each plugin to use /bot, or !, or anna, etc... to reflect the syntax for each bot, just add [botalias] in the command help line.
This is then replaced with the first defined botalias when the help is echoed.