### PR TITLE
Fixed issue #714 with incomplete Profilesync

### DIFF
--- a/hangupsbot/plugins/telesync/__init__.py
+++ b/hangupsbot/plugins/telesync/__init__.py
@@ -244,7 +244,8 @@ def tg_util_sync_get_user_name(msg, chat_action='from'):
     profile_dict = tg_bot.ho_bot.memory.get_by_path(['profilesync'])['tg2ho']
     username = TelegramBot.get_username(msg, chat_action=chat_action)
     logger.info("message from: {}".format(msg['from']['id']))
-    if str(msg['from']['id']) in profile_dict:
+    if str(msg['from']['id']) in profile_dict \
+            and "user_gplus" in profile_dict[str(msg['from']['id'])]:
         # logger.info("message from: {}".format(msg['from']['id']))
         user_html = profile_dict[str(msg['from']['id'])]['user_text']
     else:

--- a/hangupsbot/plugins/telesync/__init__.py
+++ b/hangupsbot/plugins/telesync/__init__.py
@@ -736,8 +736,6 @@ def syncprofile(bot, event, *args):
             new_mem = {'tg2ho': tg2ho_dict, 'ho2tg': ho2tg_dict}
             bot.memory.set_by_path(['profilesync'], new_mem)
             yield from bot.coro_send_message(event.conv_id, "Succsesfully set up profile sync.")
-            yield from bot.coro_send_message(event.conv_id,
-                                             "Syncing ho: {} with tg: {}".format(event.user_id.chat_id, ho2tg_dict))
         else:
             yield from bot.coro_send_message(event.conv_id,
                                              "You have to execute following command from telegram first:")


### PR DESCRIPTION
If the /syncprofile procedure isn't completed, telegram name is used until profile sync is completed.