### PR TITLE
Spawn case

### DIFF
--- a/hangupsbot/hangupsbot.py
+++ b/hangupsbot/hangupsbot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.5
 import appdirs, argparse, asyncio, gettext, logging, logging.config, os, shutil, signal, sys, time
 
 import hangups

--- a/hangupsbot/hangupsbot.py
+++ b/hangupsbot/hangupsbot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.5
+#!/usr/bin/env python3
 import appdirs, argparse, asyncio, gettext, logging, logging.config, os, shutil, signal, sys, time
 
 import hangups

--- a/hangupsbot/plugins/spawn.py
+++ b/hangupsbot/plugins/spawn.py
@@ -82,6 +82,7 @@ def _initialize(bot):
 
     # override the load logic and register our commands directly
     for cmd in cmds:
+        cmds[cmd]=cmds[cmd].pop(cmd.lower())
         command.register(_spawn, admin=True, final=True, name=cmd)
 
     logger.info("spawn - %s", ", ".join(['*' + cmd for cmd in cmds]))
@@ -91,7 +92,7 @@ def _initialize(bot):
 def _spawn(bot, event, *args):
     """Execute a generic command"""
     config = bot.get_config_suboption(event.conv_id, "spawn")
-    cmd_config = config["commands"][event.command_name]
+    cmd_config = config["commands"][event.command_name.lower()]
 
     home_env = cmd_config.get("home", config.get("home"))
     if home_env:

--- a/hangupsbot/plugins/spawn.py
+++ b/hangupsbot/plugins/spawn.py
@@ -72,17 +72,23 @@ from commands import command
 
 logger = logging.getLogger(__name__)
 
+"""translate dict keys to lowercase"""
+def toLower(mydict):
+    return dict((k.lower(),toLower(v) if hasattr(v,'keys') else v) for k,v in mydict.items())
+
+
 def _initialize(bot):
     bot.spawn_lock = asyncio.Lock()
     config = bot.get_config_option("spawn")
     if not config:
         return
 
+
     cmds = config.get("commands")
+    cmds = toLower(cmds)
 
     # override the load logic and register our commands directly
     for cmd in cmds:
-        cmds[cmd]=cmds[cmd].pop(cmd.lower())
         command.register(_spawn, admin=True, final=True, name=cmd)
 
     logger.info("spawn - %s", ", ".join(['*' + cmd for cmd in cmds]))
@@ -92,7 +98,10 @@ def _initialize(bot):
 def _spawn(bot, event, *args):
     """Execute a generic command"""
     config = bot.get_config_suboption(event.conv_id, "spawn")
-    cmd_config = config["commands"][event.command_name.lower()]
+
+    # translate spawn commands & event name to lower for standardized read
+    cmds = toLower(config["commands"])
+    cmd_config = cmds[event.command_name.lower()]
 
     home_env = cmd_config.get("home", config.get("home"))
     if home_env:

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ slackclient >=0.16 # slackrtm (includes websockets)
 textblob
 python_dateutil # gitlab sink
 telepot == 7.1 # telegram sync, newer versions doesn't support Python3.4.1
+CaseInsensitiveDict # spawn


### PR DESCRIPTION
Translate dict keys in command list and event.command_name to lowercase for standardized read.
* This helps when bot alias is `.` as phone keyboards will auto uppercase the first letter after a period
* example: `. define word` will be auto-cased to `. Define word` which breaks the spawn command