### PR TITLE
autoreply - Multiple updates

### DIFF
--- a/hangupsbot/plugins/autoreply.py
+++ b/hangupsbot/plugins/autoreply.py
@@ -4,6 +4,8 @@ import hangups
 
 import plugins
 
+from plugins._validate_image_links import imagelink
+
 logger = logging.getLogger(__name__)
 #modified version of the original autoreply allowing for images to be posted to the chat.
 def _initialise(bot):
@@ -149,22 +151,7 @@ def send_reply(bot, event, message):
             envelopes.append((target_conv, message.format(**values)))
 
     else:
-        if " " in message:
-            """immediately reject anything with spaces, must be a link"""
-            probable_image_link = False
-
-        message_lower = message.lower()
-        logger.info("link? {}".format(message_lower))
-
-        if re.match("^(https?://)?([a-z0-9.]*?\.)?imgur.com/", message_lower, re.IGNORECASE):
-            """imgur links can be supplied with/without protocol and extension"""
-            probable_image_link = True
-
-        elif message_lower.startswith(("http://", "https://")) and message_lower.endswith((".png", ".gif", ".gifv", ".jpg", ".jpeg")):
-            """other image links must have protocol and end with valid extension"""
-            probable_image_link = True
-        else:
-            probable_image_link = False
+        message, probable_image_link=imagelink(message)
 
         if probable_image_link:
             if "imgur.com" in message:

--- a/hangupsbot/plugins/autoreply.py
+++ b/hangupsbot/plugins/autoreply.py
@@ -1,13 +1,11 @@
-import asyncio, re, logging, json, random
+import asyncio, re, logging, json, random, aiohttp, io, os
 
 import hangups
 
 import plugins
 
-
 logger = logging.getLogger(__name__)
-
-
+#modified version of the original autoreply allowing for images to be posted to the chat.
 def _initialise(bot):
     plugins.register_handler(_handle_autoreply, type="message")
     plugins.register_handler(_handle_autoreply, type="membership")
@@ -39,7 +37,56 @@ def _handle_autoreply(bot, event, command):
     else:
         raise RuntimeError("unhandled event type")
 
+    # get_config_suboption returns the convo specific autoreply settings. If none set, it returns the global settings.
     autoreplies_list = bot.get_config_suboption(event.conv_id, 'autoreplies')
+    
+    # load any global settings as well
+    autoreplies_list_global = bot.get_config_option('autoreplies')
+
+    # If the global settings loaded from get_config_suboption then we now have them twice and don't need them, so can be ignored.
+    if autoreplies_list_global and autoreplies_list_global is not autoreplies_list:
+        autoreplies_list_extend=[]
+
+        # If the two are different, then iterate through each of the triggers in the global list and if they
+        # match any of the triggers in the convo list then discard them.
+        # Any remaining at the end of the loop are added to the first list to form a consolidated list
+        # of per-convo and global triggers & replies, with per-convo taking precident.
+        
+        # Loop through list of global triggers e.g. ["hi","hello","hey"],["baf","BAF"].
+        for kwds_gbl, sentences_gbl in autoreplies_list_global:
+
+            discard_me = 0
+            if isinstance(kwds_gbl, list):
+                # Loop through nested list of global triggers e.g. "hi","hello","hey".
+                for kw_gbl in kwds_gbl:
+
+                    # Loop through list of convo triggers e.g. ["hi"],["hey"].
+                    for kwds, sentences in autoreplies_list:
+
+                        if isinstance(kwds, list):
+                            # Loop through nested list of convo triggers e.g. "hi".
+                            for kw in kwds:
+
+                                # If any match, stop searching this set.
+                                if kw == kw_gbl:
+                                    discard_me = 1
+                                    break
+
+                        if discard_me == 1:
+                            break
+
+                    if discard_me == 1:
+                        break
+
+            # If there are no overlaps (i.e. no instance of global trigger in convo trigger list), add to the list.
+            if discard_me == 0:
+                autoreplies_list_extend.extend([kwds_gbl, sentences_gbl])
+                break
+
+        # Extend original list with non-disgarded entries.
+        if autoreplies_list_extend:
+            autoreplies_list.extend([autoreplies_list_extend])
+
     if autoreplies_list:
         for kwds, sentences in autoreplies_list:
 
@@ -47,6 +94,14 @@ def _handle_autoreply(bot, event, command):
                 message = random.choice(sentences)
             else:
                 message = sentences
+
+            
+            # [MD] Added call to shared tldr functionality to permit posting the convo tldr in an 
+            #      autoreply if [tldr] is encountered in a message
+            if "[tldr]" in message:
+                args = {'conv_id': event.conv_id, 'params': ''}
+                tldrmsg = bot.call_shared("plugin_tldr_shared",bot,args)
+                message = message.replace("[tldr]", tldrmsg)
 
             if isinstance(kwds, list):
                 for kw in kwds:
@@ -94,7 +149,45 @@ def send_reply(bot, event, message):
             envelopes.append((target_conv, message.format(**values)))
 
     else:
-        envelopes.append((event.conv, message.format(**values)))
+        if " " in message:
+            """immediately reject anything with spaces, must be a link"""
+            probable_image_link = False
+
+        message_lower = message.lower()
+        logger.info("link? {}".format(message_lower))
+
+        if re.match("^(https?://)?([a-z0-9.]*?\.)?imgur.com/", message_lower, re.IGNORECASE):
+            """imgur links can be supplied with/without protocol and extension"""
+            probable_image_link = True
+
+        elif message_lower.startswith(("http://", "https://")) and message_lower.endswith((".png", ".gif", ".gifv", ".jpg", ".jpeg")):
+            """other image links must have protocol and end with valid extension"""
+            probable_image_link = True
+        else:
+            probable_image_link = False
+
+        if probable_image_link:
+            if "imgur.com" in message:
+                """special imgur link handling"""
+                if not message.endswith((".jpg", ".gif", "gifv", "webm", "png")):
+                    message = message + ".gif"
+                message = "https://i.imgur.com/" + os.path.basename(message)
+
+            message = message.replace(".webm",".gif")
+            message = message.replace(".gifv",".gif")
+
+            logger.info("getting {}".format(message))
+
+            filename = os.path.basename(message)
+            r = yield from aiohttp.request('get', message)
+            raw = yield from r.read()
+            image_data = io.BytesIO(raw)
+
+            image_id = yield from bot._client.upload_image(image_data, filename=filename)
+
+            yield from bot.coro_send_message(event.conv.id_, None, image_id=image_id)
+        else:
+            envelopes.append((event.conv, message.format(**values)))
 
     for send in envelopes:
         yield from bot.coro_send_message(*send)


### PR DESCRIPTION
Bring across changes to permit images as auto-replies [not sure of author]
Add call to shared tldr to permit using tldr in auto-replies.
Specify per convo autoreplies without excluding global entries. Convo specific entries are loaded first, global entries are then added if they don't match any of the triggers in the per convo list.

N.B.: I've tried to explain methodology for my changes so that if they can be made more 'Python-y' prior to merge, please do.