### PR TITLE
Make it easier to whitelist hangouts for restrictedadd

### DIFF
--- a/hangupsbot/plugins/restrictedadd.py
+++ b/hangupsbot/plugins/restrictedadd.py
@@ -72,7 +72,7 @@ def _check_if_admin_added_me(bot, event, command):
                         initiator_user_id, event.user.full_name, event.conv_id))
 
                     notify = bot.config.get_option('botkeeper_check_notify')
-                    print(notify)
+
                     if notify is True:
                         yield from bot.coro_send_to_user_and_conversation(
                             _botkeeper_list(bot, event.conv_id)[0], event.conv_id,

--- a/hangupsbot/plugins/restrictedadd.py
+++ b/hangupsbot/plugins/restrictedadd.py
@@ -88,6 +88,9 @@ def _check_if_admin_added_me(bot, event, command):
 
                     yield from _leave_the_chat_quietly(bot, event, command)
 
+            elif initiator_user_id == bot.user_self()["chat_id"]:
+                logger.info("bot added self to {}".format(event.conv_id))
+
 
 @asyncio.coroutine
 def _verify_botkeeper_presence(bot, event, command):
@@ -143,7 +146,7 @@ def _verify_botkeeper_presence(bot, event, command):
 
 @asyncio.coroutine
 def _leave_the_chat_quietly(bot, event, command):
-    yield from asyncio.sleep(1.0)
+    yield from asyncio.sleep(10.0)
     yield from command.run(bot, event, *["leave", "quietly"])
 
 

--- a/hangupsbot/plugins/restrictedadd.py
+++ b/hangupsbot/plugins/restrictedadd.py
@@ -74,7 +74,7 @@ def _check_if_admin_added_me(bot, event, command):
                         initiator_user_id, event.user.full_name, event.conv_id))
 
                     notify = bot.config.get_option('botkeeper_check_notify')
-                    print(notify)
+
                     if notify is True:
                         yield from bot.coro_send_to_user_and_conversation(
                             _botkeeper_list(bot, event.conv_id)[0], event.conv_id,

--- a/hangupsbot/plugins/restrictedadd.py
+++ b/hangupsbot/plugins/restrictedadd.py
@@ -191,7 +191,7 @@ def removebotadd(bot, event, user_id, *args):
 def botaddnotify(bot, event, conv_id):
     """<br />[botalias] <i><b>botaddnotify</b> <conv_id></i><br />Toggle whitelisting a conversation to avoid botkeeper checks.<br /><u>Usage</u><br />[botalias] <i><b>botaddnotify</b> AbcdefGHIjklmNOPQRStuVWXyz</i>"""
     
-    if bot.config.exists(["conversations", convid, "strict_botkeeper_check"])
+    if bot.config.exists(["conversations", convid, "strict_botkeeper_check"]):
         conv_settings = bot.config.get_by_path(['conversations', event.conv_id])
         del conv_settings['strict_botkeeper_check'] # remove setting
 


### PR DESCRIPTION
When the bot is added to a hangout with no botkeeper, or where strict_botkeeper_check is true, PM the bot admin with the details.
Echo the command to permit whitelisting the conversation so that it will remain the next time.

Add the dedicated add/remove whitelist commands.