### PR TITLE
Add optional pin/location support for spawn

### DIFF
--- a/hangupsbot/plugins/spawn.py
+++ b/hangupsbot/plugins/spawn.py
@@ -12,6 +12,7 @@ whether it is an admin command or not.
 
     "spawn": {
         "home": "/nonstandard/home/directory",
+        "map_regex": "<regular expression to override standard if necessary>",
         "commands":
             "fortune": {
                 "command": ["/usr/games/fortune"]
@@ -23,7 +24,8 @@ whether it is an admin command or not.
             "stock-info": {
                 "command": ["/home/portfolio/stock-info", "--"]
                 "home": "/home/portfolio",
-                "allow_args": true
+                "allow_args": true,
+                "allow_location": true
         }
     }
 

--- a/hangupsbot/plugins/spawn.py
+++ b/hangupsbot/plugins/spawn.py
@@ -16,9 +16,9 @@ whether it is an admin command or not.
             "fortune": {
                 "command": ["/usr/games/fortune"]
             },
-            "motd": {    <---this is a deliberately unsecure example
-                "command": ["/bin/cat", "/etc/motd", "--"],
-                "allow_args": true
+            "motd": {    <---this is a deliberately unsecure example DO NOT DO THIS!!!
+                "command": ["/bin/cat", "/etc/motd", "--"], <--- "--" is not sufficient!
+                "allow_args": true                          <--- be very careful with allow_args
             },
             "stock-info": {
                 "command": ["/home/portfolio/stock-info", "--"]
@@ -63,14 +63,27 @@ the subprocess, along with additional helpers (see code below).
 """
 
 import os
+import re
 import logging
 import asyncio
 from asyncio.subprocess import PIPE
+from datetime import datetime, timedelta, timezone
 
 from commands import command
 import plugins
 
 logger = logging.getLogger(__name__)
+
+_MAP_REGEX = \
+    r"\bhttps?://" + \
+    r"(goo\.gl/maps/|(www\.)?google\.com/maps|maps\.google\.com|" + \
+    r"(www\.)?ingress\.com/intel|" + \
+    r"maps\.apple\.com)\S+\b"
+
+# pylint: disable=global-statement
+_MAP_PINS = {}
+_MAP_MATCH = None
+
 
 def _initialize(bot):
     bot.spawn_lock = asyncio.Lock()
@@ -81,11 +94,38 @@ def _initialize(bot):
     cmds = config.get("commands")
 
     # override the load logic and register our commands directly
-    for cmd in cmds:
+    get_location = False
+    for cmd, cnf in cmds.items():
         command.register(_spawn, admin=True, final=True, name=cmd)
+        if cnf.get("allow_location"):
+            get_location = True
 
     logger.info("spawn - %s", ", ".join(['*' + cmd for cmd in cmds]))
     plugins.register_admin_command(list(cmds))
+
+    if get_location:
+        global _MAP_MATCH
+        _MAP_MATCH = re.compile(config.get("map_regex", _MAP_REGEX), re.IGNORECASE|re.MULTILINE)
+        plugins.register_handler(_location_handler, type="message")
+
+
+def _expire_old_pins():
+    global _MAP_PINS
+    now = datetime.now(timezone.utc)
+    _MAP_PINS = {key:_MAP_PINS[key] for key in _MAP_PINS if _MAP_PINS[key]["expires"] > now}
+
+
+def _location_handler(dummy_bot, event):
+    """Save any urls that look like maps for latter pin/location requests"""
+    if event.user.is_self:
+        return
+    match = _MAP_MATCH.search(event.text)
+    if match:
+        _MAP_PINS[(event.conv_id, event.user_id)] = {
+            'url': match.group(0),
+            'expires': event.timestamp + timedelta(minutes=30)
+        }
+        _expire_old_pins()
 
 
 def _spawn(bot, event, *args):
@@ -115,6 +155,12 @@ def _spawn(bot, event, *args):
         'HANGOUT_CONV_TAGS': ','.join(bot.tags.useractive(event.user_id.chat_id,
                                                           event.conv_id))
     }
+    if cmd_config.get("allow_location"):
+        _expire_old_pins()
+        last_pin = _MAP_PINS.get((event.conv_id, event.user_id))
+        if last_pin:
+            environment.update({'HANGOUT_USER_LOCATION': last_pin['url']})
+
     environment.update(dict(os.environ))
 
     proc = yield from asyncio.create_subprocess_exec(*executable, stdout=PIPE, stderr=PIPE,


### PR DESCRIPTION
If a command has been tagged with "allow_location", and the user has dropped a pin in that hangout in the previous 30 minutes, we'll pass along that pin to the spawned program in HANGOUT_USER_LOCATION.