### PR TITLE
featureset #737 -> staging

### DIFF
--- a/hangupsbot/plugins/restrictedadd.py
+++ b/hangupsbot/plugins/restrictedadd.py
@@ -54,12 +54,14 @@ def _check_if_admin_added_me(bot, event, command):
             # bot was part of the event
             initiator_user_id = event.user_id.chat_id
 
-            # check if botkeeper added, including self (ie, add by link)
             if initiator_user_id in _botkeeper_list(bot, event.conv_id):
                 logger.info("botkeeper added me to {}".format(event.conv_id))
 
             elif initiator_user_id == bot.user_self()["chat_id"]:
                 logger.info("bot added self to {}".format(event.conv_id))
+
+            elif event.conv_id in self.bot.conversations.get("tag:restrictedadd-whitelist"):
+                logger.info("bot added to whitelisted {}".format(event.conv_id))
 
             else:
                 logger.warning("{} ({}) tried to add me to {}".format(
@@ -75,6 +77,9 @@ def _check_if_admin_added_me(bot, event, command):
 @asyncio.coroutine
 def _verify_botkeeper_presence(bot, event, command):
     if not bot.get_config_suboption(event.conv_id, 'strict_botkeeper_check'):
+        return
+
+    if event.conv_id in self.bot.conversations.get("tag:restrictedadd-whitelist"):
         return
 
     try:


### PR DESCRIPTION
# whitelist conversation from strict-checking
deactivate botkeeper checks on specific conversations with:
```
/bot tagset conv <convid> restrictedadd-whitelist
```
note: overrides global `strict_botkeeper_check`

# notify on unauthorised adds
note: uses the using the system plugin [Logger to Chat](https://github.com/hangoutsbot/hangoutsbot/wiki/Logger-to-Chat-Message), which is not part of this pr - documented here since it was a feature that was implemented in #737 

capture warnings from restrictedadd with:
```
/bot logconfig plugins.restrictedadd 30
```
redirect to admin conversations you want by tagging the conversation id with `receive-logs`:
```
/bot tagset conv <adminconvid> receive-logs
```
