### PR TITLE
Fix SlackRTM's :simple_smile: alias

### DIFF
--- a/hangupsbot/plugins/slackrtm.py
+++ b/hangupsbot/plugins/slackrtm.py
@@ -62,8 +62,8 @@ import html # for html.unescape
 logger = logging.getLogger(__name__)
 
 # fix for simple_smile support
-emoji.EMOJI_UNICODE[':simple_smile:'] = emoji.EMOJI_UNICODE[':white_smiling_face:']
-emoji.EMOJI_ALIAS_UNICODE[':simple_smile:'] = emoji.EMOJI_UNICODE[':white_smiling_face:']
+emoji.EMOJI_UNICODE[':simple_smile:'] = emoji.EMOJI_UNICODE[':smiling_face:']
+emoji.EMOJI_ALIAS_UNICODE[':simple_smile:'] = emoji.EMOJI_UNICODE[':smiling_face:']
 
 def chatMessageEvent2SlackText(event):
     def renderTextSegment(segment):


### PR DESCRIPTION
`:white_smiling_face:` doesn't appear to exist in emoji 0.4.5.

```
ERROR plugins: EXCEPTION during plugin import: plugins.slackrtm
Traceback (most recent call last):
  File "hangoutsbot/hangupsbot/plugins/__init__.py", line 328, in load
    importlib.import_module(module_path)
  File "hangoutsbot/venv/lib/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 978, in _gcd_import
  File "<frozen importlib._bootstrap>", line 961, in _find_and_load
  File "<frozen importlib._bootstrap>", line 950, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 655, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 205, in _call_with_frames_removed
  File "hangoutsbot/hangupsbot/plugins/slackrtm.py", line 66, in <module>
    emoji.EMOJI_UNICODE[':simple_smile:'] = emoji.EMOJI_UNICODE[':white_smiling_face:']
KeyError: ':white_smiling_face:'
```

This replaces it with `:smiling_face:` instead.