### PR TITLE
[v3] update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,10 @@ git+https://github.com/carpedm20/emoji
 selenium # screenshots
 google-api-python-client # for spotify
 spotipy
+soundcloud # for spotify
 slackclient >=0.16 # slackrtm (includes websockets)
 textblob
 python_dateutil # gitlab sink
 telepot == 7.1 # telegram sync, newer versions doesn't support Python3.4.1
 cleverwrap # cleverbot
+TwitterAPI # for twitter


### PR DESCRIPTION
[spotify.py](https://github.com/hangoutsbot/hangoutsbot/blob/master/hangupsbot/plugins/spotify.py#L20) and [twitter.py](https://github.com/hangoutsbot/hangoutsbot/blob/master/hangupsbot/plugins/twitter.py#L2) were both importing libraries, specifically the `soundcloud` and `TwitterAPI` library respectively, that were not part of the requirements.txt file

See #806 for v2 PR