### PR TITLE
update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,20 +6,20 @@ aiohttp>=1.0,<1.1
 jsonrpclib-pelix
 
 # PLUGIN DEPENDENCIES #
-beautifulsoup4
-pushbullet.py # mentions
-goslate # translations
-wikipedia
-wolframalpha
-git+https://github.com/loisaidasam/pyslack.git # slack
-git+https://github.com/carpedm20/emoji
-selenium # screenshots
-google-api-python-client # for spotify
-spotipy
-soundcloud # for spotify
-slackclient >=0.16 # slackrtm (includes websockets)
-textblob
-python_dateutil # gitlab sink
-telepot == 7.1 # telegram sync, newer versions doesn't support Python3.4.1
-cleverwrap # cleverbot
-TwitterAPI # for twitter
+
+python_dateutil                                 # sinks: gitlab
+pushbullet.py                                   # plugins: mentions
+goslate                                         # plugins: simplytranslate, syncrooms_autotranslate
+textblob                                        # plugins: plugins: simplytranslate, syncrooms_autotranslate
+wikipedia                                       # plugins: simplewikipedia
+wolframalpha                                    # plugins: wolframalpha
+git+https://github.com/carpedm20/emoji          # plugins: slack, slackrtm
+git+https://github.com/loisaidasam/pyslack.git  # plugins: slack
+slackclient >=0.16                              # plugins: slackrtm
+selenium                                        # plugins: image_screenshot
+telepot == 7.1                                  # plugins: telesync
+cleverwrap                                      # plugins: cleverbot
+TwitterAPI                                      # plugins: twitter
+google-api-python-client                        # plugins: spotify
+spotipy                                         # plugins: spotify
+soundcloud                                      # plugins: spotify

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,8 +16,10 @@ git+https://github.com/carpedm20/emoji
 selenium # screenshots
 google-api-python-client # for spotify
 spotipy
+soundcloud # for spotify
 slackclient >=0.16 # slackrtm (includes websockets)
 textblob
 python_dateutil # gitlab sink
 telepot == 7.1 # telegram sync, newer versions doesn't support Python3.4.1
 cleverwrap # cleverbot
+TwitterAPI # for twitter

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ jsonrpclib-pelix
 python_dateutil                                 # sinks: gitlab
 pushbullet.py                                   # plugins: mentions
 goslate                                         # plugins: simplytranslate, syncrooms_autotranslate
-textblob                                        # plugins: plugins: simplytranslate, syncrooms_autotranslate
+textblob                                        # plugins: simplytranslate, syncrooms_autotranslate
 wikipedia                                       # plugins: simplewikipedia
 wolframalpha                                    # plugins: wolframalpha
 git+https://github.com/carpedm20/emoji          # plugins: slack, slackrtm


### PR DESCRIPTION
[spotify.py](https://github.com/hangoutsbot/hangoutsbot/blob/master/hangupsbot/plugins/spotify.py#L20) and [twitter.py](https://github.com/hangoutsbot/hangoutsbot/blob/master/hangupsbot/plugins/twitter.py#L2) were both importing libraries, specifically the `soundcloud` and `TwitterAPI` library respectively, that were not part of the requirements.txt file

Note: this is a resubmitted PR of #806, which had a broken commit log
Also, this should not be merged into v3, as this method of installing dependencies is not an ideal solution (closed PR #807). Instead, an attempt should be made in moving plugin-based requirements into their respective modules.