### PR TITLE
[v3] Add "history" handler for OTR events

### DIFF
--- a/hangupsbot/handlers.py
+++ b/hangupsbot/handlers.py
@@ -34,6 +34,7 @@ class EventHandler:
                             "membership": [],
                             "message": [],
                             "rename": [],
+                            "history": [],
                             "sending":[],
                             "typing": [],
                             "watermark": [] }
@@ -48,7 +49,7 @@ class EventHandler:
 
     def register_handler(self, function, type="message", priority=50):
         """registers extra event handlers"""
-        if type in ["allmessages", "call", "membership", "message", "rename", "typing", "watermark"]:
+        if type in ["allmessages", "call", "membership", "message", "rename", "history", "typing", "watermark"]:
             if not asyncio.iscoroutine(function):
                 # transparently convert into coroutine
                 function = asyncio.coroutine(function)
@@ -303,6 +304,11 @@ class EventHandler:
         yield from self.run_pluggable_omnibus("rename", self.bot, event, command)
 
     @asyncio.coroutine
+    def handle_chat_history(self, event):
+        """handle conversation OTR status change"""
+        yield from self.run_pluggable_omnibus("history", self.bot, event, command)
+
+    @asyncio.coroutine
     def handle_call(self, event):
         """handle incoming calls (voice/video)"""
         yield from self.run_pluggable_omnibus("call", self.bot, event, command)
@@ -383,6 +389,8 @@ class HandlerBridge:
             event_type = "membership"
         elif event is hangups.RenameEvent:
             event_type = "rename"
+        elif event is hangups.OTREvent:
+            event_type = "history"
         elif type(event) is str:
             event_type = str # accept all kinds of strings, just like register_handler
         else:

--- a/hangupsbot/hangupsbot.py
+++ b/hangupsbot/hangupsbot.py
@@ -628,6 +628,11 @@ class HangupsBot(object):
                 self._handlers.handle_chat_rename(event)
             ).add_done_callback(lambda future: future.result())
 
+        elif isinstance(conv_event, hangups.OTREvent):
+            asyncio.async(
+                self._handlers.handle_chat_history(event)
+            ).add_done_callback(lambda future: future.result())
+
         elif type(conv_event) is hangups.conversation_event.HangoutEvent:
             asyncio.async(
                 self._handlers.handle_call(event)
@@ -636,7 +641,6 @@ class HangupsBot(object):
         else:
             """
             XXX: Unsupported Events:
-            * OTREvent
             * GroupLinkSharingModificationEvent
             re: https://github.com/tdryer/hangups/blob/master/hangups/conversation_event.py
             """


### PR DESCRIPTION
This provides `history` as a new handler type for OTR status changes.

v3 only as it depends on `hangups.OTREvent`, which is newer than the pinned hangups version used in v2.