### PR TITLE
Fix extra reloads & warnings when bridging groups

### DIFF
--- a/hangupsbot/plugins/slackrtm/commands_hangouts.py
+++ b/hangupsbot/plugins/slackrtm/commands_hangouts.py
@@ -123,7 +123,7 @@ def slack_users(bot, event, *args):
 
     slackrtm.update_channelinfos()
     channelid = args[1]
-    channelname = slackrtm.get_groupname(channelid, slackrtm.get_channelname(channelid))
+    channelname = slackrtm.get_channelgroupname(channelid)
     if not channelname:
         yield from bot.coro_send_message(
             event.conv_id,
@@ -155,7 +155,7 @@ def slack_listsyncs(bot, event, *args):
                     break
             lines.append("{} : {} ({})\n  {} ({})\n  {}".format(
                 slackrtm.name,
-                slackrtm.get_channelname(sync.channelid),
+                slackrtm.get_channelgroupname(sync.channelid),
                 sync.channelid,
                 hangoutname,
                 sync.hangoutid,
@@ -188,7 +188,7 @@ def slack_syncto(bot, event, *args):
         return
 
     channelid = args[1]
-    channelname = slackrtm.get_groupname(channelid, slackrtm.get_channelname(channelid))
+    channelname = slackrtm.get_channelgroupname(channelid)
     if not channelname:
         yield from bot.coro_send_message(
             event.conv_id,
@@ -224,7 +224,7 @@ def slack_disconnect(bot, event, *args):
         return
 
     channelid = args[1]
-    channelname = slackrtm.get_groupname(channelid, slackrtm.get_channelname(channelid))
+    channelname = slackrtm.get_channelgroupname(channelid)
     if not channelname:
         yield from bot.coro_send_message(
             event.conv_id,
@@ -260,7 +260,7 @@ def slack_setsyncjoinmsgs(bot, event, *args):
         return
 
     channelid = args[1]
-    channelname = slackrtm.get_groupname(channelid, slackrtm.get_channelname(channelid))
+    channelname = slackrtm.get_channelgroupname(channelid)
     if not channelname:
         yield from bot.coro_send_message(
             event.conv_id,
@@ -308,7 +308,7 @@ def slack_setimageupload(bot, event, *args):
         return
 
     channelid = args[1]
-    channelname = slackrtm.get_groupname(channelid, slackrtm.get_channelname(channelid))
+    channelname = slackrtm.get_channelgroupname(channelid)
     if not channelname:
         yield from bot.coro_send_message(
             event.conv_id,
@@ -357,7 +357,7 @@ def slack_sethotag(bot, event, *args):
         return
 
     channelid = args[1]
-    channelname = slackrtm.get_groupname(channelid, slackrtm.get_channelname(channelid))
+    channelname = slackrtm.get_channelgroupname(channelid)
     if not channelname:
         yield from bot.coro_send_message(
             event.conv_id,
@@ -409,7 +409,7 @@ def slack_setslacktag(bot, event, *args):
         return
 
     channelid = args[1]
-    channelname = slackrtm.get_groupname(channelid, slackrtm.get_channelname(channelid))
+    channelname = slackrtm.get_channelgroupname(channelid)
     if not channelname:
         yield from bot.coro_send_message(
             event.conv_id,
@@ -460,7 +460,7 @@ def slack_showslackrealnames(bot, event, *args):
         return
 
     channelid = args[1]
-    channelname = slackrtm.get_groupname(channelid, slackrtm.get_channelname(channelid))
+    channelname = slackrtm.get_channelgroupname(channelid)
     if not channelname:
         yield from bot.coro_send_message(
             event.conv_id,

--- a/hangupsbot/plugins/slackrtm/commands_slack.py
+++ b/hangupsbot/plugins/slackrtm/commands_slack.py
@@ -245,13 +245,8 @@ def listsyncs(slackbot, msg, args):
             if c.id_ == sync.hangoutid:
                 hangoutname = slackbot.bot.conversations.get_name(c, truncate=False)
                 break
-        channelname = 'unknown'
-        if sync.channelid.startswith('C'):
-            channelname = slackbot.get_channelname(sync.channelid)
-        elif sync.channelid.startswith('G'):
-            channelname = slackbot.get_groupname(sync.channelid)
         message += '*%s (%s) : %s (%s)* _%s_\n' % (
-            channelname,
+            slackbot.get_channelgroupname(sync.channelid, 'unknown'),
             sync.channelid,
             hangoutname,
             sync.hangoutid,
@@ -302,7 +297,7 @@ def syncto(slackbot, msg, args):
     if msg.channel.startswith('D'):
         channelname = 'DM'
     else:
-        channelname = '#%s' % slackbot.get_channelname(msg.channel)
+        channelname = '#%s' % slackbot.get_channelgroupname(msg.channel)
 
     try:
         slackbot.config_syncto(msg.channel, hangoutid, shortname)
@@ -342,7 +337,7 @@ def disconnect(slackbot, msg, args):
     if msg.channel.startswith('D'):
         channelname = 'DM'
     else:
-        channelname = '#%s' % slackbot.get_channelname(msg.channel)
+        channelname = '#%s' % slackbot.get_channelgroupname(msg.channel)
     try:
         slackbot.config_disconnect(msg.channel, hangoutid)
     except NotSyncingError:
@@ -386,7 +381,7 @@ def setsyncjoinmsgs(slackbot, msg, args):
     if msg.channel.startswith('D'):
         channelname = 'DM'
     else:
-        channelname = '#%s' % slackbot.get_channelname(msg.channel)
+        channelname = '#%s' % slackbot.get_channelgroupname(msg.channel)
 
     if enable.lower() in ['true', 'on', 'y', 'yes']:
         enable = True
@@ -447,7 +442,7 @@ def sethotag(slackbot, msg, args):
     if msg.channel.startswith('D'):
         channelname = 'DM'
     else:
-        channelname = '#%s' % slackbot.get_channelname(msg.channel)
+        channelname = '#%s' % slackbot.get_channelgroupname(msg.channel)
 
     if hotag == "none":
         hotag = None
@@ -507,7 +502,7 @@ def setimageupload(slackbot, msg, args):
     if msg.channel.startswith('D'):
         channelname = 'DM'
     else:
-        channelname = '#%s' % slackbot.get_channelname(msg.channel)
+        channelname = '#%s' % slackbot.get_channelgroupname(msg.channel)
 
     if upload.lower() in ['true', 'on', 'y', 'yes']:
         upload = True
@@ -566,7 +561,7 @@ def setslacktag(slackbot, msg, args):
     if msg.channel.startswith('D'):
         channelname = 'DM'
     else:
-        channelname = '#%s' % slackbot.get_channelname(msg.channel)
+        channelname = '#%s' % slackbot.get_channelgroupname(msg.channel)
 
     if slacktag == "none":
         slacktag = None
@@ -625,7 +620,7 @@ def showslackrealnames(slackbot, msg, args):
     if msg.channel.startswith('D'):
         channelname = 'DM'
     else:
-        channelname = '#%s' % slackbot.get_channelname(msg.channel)
+        channelname = '#%s' % slackbot.get_channelgroupname(msg.channel)
 
     if realnames.lower() in ['true', 'on', 'y', 'yes']:
         realnames = True

--- a/hangupsbot/plugins/slackrtm/core.py
+++ b/hangupsbot/plugins/slackrtm/core.py
@@ -426,6 +426,15 @@ class SlackRTM(object):
             channelinfos[c['id']] = c
         self.channelinfos = channelinfos
 
+    def get_channelgroupname(self, channel, default=None):
+        if channel.startswith('C'):
+            return self.get_channelname(channel, default)
+        if channel.startswith('G'):
+            return self.get_groupname(channel, default)
+        if channel.startswith('D'):
+            return 'DM'
+        return default
+
     def get_channelname(self, channel, default=None):
         if channel not in self.channelinfos:
             logger.debug('channel not found, reloading channels')
@@ -482,7 +491,8 @@ class SlackRTM(object):
             if linktext != "":
                 out = "#%s" % linktext
             else:
-                out = "#%s" % self.get_channelname(match.group(3), 'unknown:%s' % match.group(3))
+                out = "#%s" % self.get_channelgroupname(match.group(3),
+                                                        'unknown:%s' % match.group(3))
         else:
             linktarget = match.group(1)
             if linktext == "":
@@ -707,7 +717,7 @@ class SlackRTM(object):
 
             if msg.from_ho_id != sync.hangoutid:
                 username = msg.realname4ho if sync.showslackrealnames else msg.username4ho
-                channel_name = self.get_channelname(msg.channel)
+                channel_name = self.get_channelgroupname(msg.channel)
 
                 if msg.file_attachment:
                     if sync.image_upload:


### PR DESCRIPTION
If you're bridging a private group to a hangout, we were constantly reloading channel names unnecessarily.

`Apr 10 11:46:09 charlie ashbot[17796]: WARNING plugins.slackrtm.core: could not find channel "XXXXXX" although reloaded`

I'm not super-happy with the naming of this new function, but I'm trying to be vaguely (and misguidedly conservative).  We should probably call the new function get_channelname() or get_slackname()), and make all of the other sub-functions private (e.g. _get_channelname()).  Code outside of core should never be calling the 'real' get_channelname or get_groupname).

