### PR TITLE
Fix DM commands

### DIFF
--- a/hangupsbot/plugins/slackrtm/core.py
+++ b/hangupsbot/plugins/slackrtm/core.py
@@ -687,9 +687,10 @@ class SlackRTM(object):
             return
 
         syncs = self.get_syncs(channelid=msg.channel)
-        if not syncs:
-            """since slackRTM listens to everything, we need a quick way to filter out noise. this also
-            has the added advantage of making slackrtm play well with other slack plugins"""
+        if not syncs and not msg.channel.startswith('D'):
+            # since slackRTM listens to everything, we need a quick way to filter out noise.
+            # this also has the added advantage of making slackrtm play well with other slack
+            # plugins
             return
 
         reffmt = re.compile(r'<((.)([^|>]*))((\|)([^>]*)|([^>]*))>')


### PR DESCRIPTION
Unable to send a command to SlackRTM via DM (needed for private admin only commands).

Admins need to be able to send private commands to SlackRTM via DM, but the early check for
is the channel synced was cutting them out.