### PR TITLE
Config Update

### DIFF
--- a/hangupsbot/config.py
+++ b/hangupsbot/config.py
@@ -1,3 +1,5 @@
+"""cache for a json file with shortscuts to access data"""
+
 import asyncio
 import collections
 from datetime import datetime
@@ -14,7 +16,14 @@ logger = logging.getLogger(__name__)
 
 
 class Config(collections.MutableMapping):
-    """Configuration JSON storage class"""
+    """Configuration JSON storage class
+
+    Args:
+        path: string, file path of the config file
+        default: any type, default value for missing data
+        failsafe_backups: int, ammount of backups that should be kept
+        save_delay: int, time in second a dump should be delayed
+    """
     def __init__(self, path, default=None, failsafe_backups=0, save_delay=0):
         self.filename = path
         self.default = default
@@ -42,6 +51,13 @@ class Config(collections.MutableMapping):
             return True
 
     def _make_failsafe_backup(self):
+        """remove old backup files above the limit and create a new backup
+
+        the limit refers to the number of .failsafe_backups
+
+        Returns:
+            boolean, True on a successful new backup, otherwise False
+        """
         try:
             with open(self.filename) as file:
                 json.load(file)
@@ -65,6 +81,12 @@ class Config(collections.MutableMapping):
         return True
 
     def _recover_from_failsafe(self):
+        """restore data from a recent backup
+
+        Returns:
+            boolean, True if any backup could be loaded, False if None is
+                available or all backups are currupt or no readable
+        """
         existing = sorted(glob.glob(self.filename + ".*.bak"))
         recovery_filename = None
         while len(existing) > 0:
@@ -85,6 +107,14 @@ class Config(collections.MutableMapping):
         return False
 
     def load(self):
+        """Load config from file
+
+        Raises:
+            IOError: the existing config is not readable or no new config can
+                be saved to the configured path
+            ValueError: the config file is not a valid json and no backups are
+                available
+        """
         try:
             with open(self.filename) as file:
                 data = file.read()
@@ -150,10 +180,24 @@ class Config(collections.MutableMapping):
         logger.info("%s write %s", self.filename, interval)
 
     def flush(self):
+        """force an immediate dump to file"""
         logger.info("flushing %s", self.filename)
         self.save(delay=False)
 
     def get_by_path(self, keys_list, fallback=True):
+        """Get an item from .config by path
+
+        Args:
+            keys_list: list, a list of strings, describing the path to the value
+            fallback: boolean, use the default values as fallback for missing
+                entrys
+
+        Returns:
+            any type, the requested value
+
+        Raises:
+            KeyError, ValueError: the path does not exist
+        """
         try:
             return self._get_by_path(self.config, keys_list)
         except (KeyError, ValueError):
@@ -166,34 +210,95 @@ class Config(collections.MutableMapping):
                                (self.filename, keys_list))
 
     def set_by_path(self, keys_list, value, create_path=True):
+        """set an item in .config by path
+
+        Args:
+            keys_list: list, a list of strings, describing the path to the value
+            value: any type, the new value
+            create_path: boolean, toogle to ensure an existing path
+
+        Raises:
+            KeyError, ValueError: the path does not exist
+        """
         if create_path:
             self.ensure_path(keys_list)
         self.get_by_path(keys_list[:-1],
                          fallback=False)[keys_list[-1]] = value
 
     def pop_by_path(self, keys_list):
+        """remove an item in .config found with the given path
+
+        Args:
+            keys_list: list, a list of strings, describing the path to the value
+
+        Returns:
+            any type, the removed value
+
+        Raises:
+            KeyError, ValueError: the path does not exist
+        """
         return self.get_by_path(keys_list[:-1], False).pop(keys_list[-1])
 
     @staticmethod
     def _get_by_path(source, path):
+        """Get an item from source by path
+
+        Args:
+            path: list, a list of strings, describing the path to the value
+
+        Returns:
+            any type, the requested value
+
+        Raises:
+            KeyError, ValueError: the path does not exist
+        """
         if not len(path):
             return source
         return functools.reduce(operator.getitem, path[:-1], source)[path[-1]]
 
     def get_option(self, keyname):
+        """get a top level entry from config or a default value
+
+        Args:
+            keyname: string, top level key
+
+        Returns:
+            any type, the requested value or .default if the key does not exist
+        """
         try:
             return self.get_by_path([keyname])
         except KeyError:
             return self.default
 
     def get_suboption(self, grouping, groupname, keyname):
+        """get a third level entry from config with a fallback to top level
+
+        Args:
+            grouping: string, top level entry in .config
+            groupname: string, second level entry, key in grouping
+            keyname: string, third level key as target and also the top level
+                key as fallback for a missing key in the path
+
+        Returns:
+            any type, the requested value, it's fallback on top level or
+                .default if the key does not exist on both level
+        """
         try:
             return self.get_by_path([grouping, groupname, keyname])
         except KeyError:
             return self.get_option(keyname)
 
     def exists(self, keys_list, fallback=False):
+        """check if a path exisits in the dict
 
+        Args:
+            keys_list: list, a list of strings describing the path
+            fallback: boolean, use the default values as fallback for missing
+                entrys
+
+        Returns:
+            boolean, True if the full path is resolvable, otherwise False
+        """
         try:
             self.get_by_path(keys_list, fallback)
             return True
@@ -201,6 +306,19 @@ class Config(collections.MutableMapping):
             return False
 
     def ensure_path(self, path, base=None):
+        """create a path of dicts if the given path does not exist
+
+        Args:
+            path: list, a list of strings describing the path
+            base: dict, the source to create the path in
+
+        Returns:
+            boolean, True if the path did not existed before, otherwise False
+
+        Raises:
+            AttributeError: on attempting to override a key pointing to an entry
+                in config that is not a dict
+        """
         if base is None:
             base = self.config
         created = not self.exists(path)
@@ -215,6 +333,20 @@ class Config(collections.MutableMapping):
         return created
 
     def set_defaults(self, source, path=None):
+        """ensure that the dict, path points to, has the structure of the source
+
+        also override to defaults if the type of an entry does not match
+
+        Args:
+            source: dict structure with values
+            path: list, a list of keys to the dict to update with defaults
+
+        Raises:
+            ValueError: the path could not be created as it would override an
+                entry that is not a dict
+            AttributeError: a value in source does not match with the type that
+                is already in the defaults
+        """
         if path is None:
             path = []
         else:
@@ -231,6 +363,18 @@ class Config(collections.MutableMapping):
                 defaults[key].extend(value)
 
     def validate(self, source, path=None):
+        """ensure that the entrys in source are all available in the config
+
+        also override to defaults if the type of an entry does not match
+
+        Args:
+            source: default dict structure with values
+            path: list of keys to the dict to validate
+
+        Raises:
+            ValueError: the path could not be created as it would override an
+                entry that is not a dict
+        """
         if path is None:
             path = []
         for key, value in source.items():

--- a/hangupsbot/config.py
+++ b/hangupsbot/config.py
@@ -214,6 +214,22 @@ class Config(collections.MutableMapping):
                                      (self.filename, last_key, path))
         return created
 
+    def set_defaults(self, source, path=None):
+        if path is None:
+            path = []
+        else:
+            self.ensure_path(path, base=self.defaults)
+        defaults = self._get_by_path(self.defaults, path)
+        for key, value in source.items():
+            if key not in defaults:
+                defaults[key] = value
+
+            elif isinstance(value, dict):
+                self.set_defaults(value, path + [key])
+
+            elif isinstance(value, list):
+                defaults[key].extend(value)
+
     def __getitem__(self, key):
         return self.get_option(key)
 

--- a/hangupsbot/config.py
+++ b/hangupsbot/config.py
@@ -48,7 +48,7 @@ class Config(collections.MutableMapping):
         except IOError:
             return False
         except ValueError:
-            logger.warning("{} is corrupted, aborting backup".format(self.filename))
+            logger.warning("%s is corrupted, aborting backup", self.filename)
             return False
 
         existing = sorted(glob.glob(self.filename + ".*.bak"))
@@ -81,7 +81,7 @@ class Config(collections.MutableMapping):
                 logger.warning('Failed to remove %s, check permissions',
                                recovery_filename)
             except ValueError:
-                logger.error("corrupted recovery: {}".format(self.filename))
+                logger.error("corrupted recovery: %s", self.filename)
         return False
 
     def load(self):

--- a/hangupsbot/config.py
+++ b/hangupsbot/config.py
@@ -188,10 +188,9 @@ class Config(collections.MutableMapping):
 
     def get_suboption(self, grouping, groupname, keyname):
         try:
-            value = self.config[grouping][groupname][keyname]
+            return self.get_by_path([grouping, groupname, keyname])
         except KeyError:
-            value = self.get_option(keyname)
-        return value
+            return self.get_option(keyname)
 
     def exists(self, keys_list):
         _exists = True

--- a/hangupsbot/config.py
+++ b/hangupsbot/config.py
@@ -43,8 +43,8 @@ class Config(collections.MutableMapping):
 
     def _make_failsafe_backup(self):
         try:
-            with open(self.filename) as f:
-                json.load(f)
+            with open(self.filename) as file:
+                json.load(file)
         except IOError:
             return False
         except ValueError:

--- a/hangupsbot/config.py
+++ b/hangupsbot/config.py
@@ -365,8 +365,6 @@ class Config(collections.MutableMapping):
     def validate(self, source, path=None):
         """ensure that the entrys in source are all available in the config
 
-        also override to defaults if the type of an entry does not match
-
         Args:
             source: default dict structure with values
             path: list of keys to the dict to validate

--- a/hangupsbot/config.py
+++ b/hangupsbot/config.py
@@ -43,7 +43,11 @@ class Config(collections.MutableMapping):
 
         existing = sorted(glob.glob(self.filename + ".*.bak"))
         while len(existing) > (self.failsafe_backups - 1):
-            os.remove(existing.pop(0))
+            path = existing.pop(0)
+            try:
+                os.remove(path)
+            except IOError:
+                logger.warning('Failed to remove %s, check permissions', path)
 
         backup_file = self.filename + "." + datetime.datetime.now().strftime("%Y%m%d%H%M%S") + ".bak"
         shutil.copy2(self.filename, backup_file)

--- a/hangupsbot/config.py
+++ b/hangupsbot/config.py
@@ -10,7 +10,7 @@ class Config(collections.MutableMapping):
     """Configuration JSON storage class"""
     def __init__(self, filename, default=None, failsafe_backups=0, save_delay=0):
         self.filename = filename
-        self.default = None
+        self.default = default
         self.config = {}
         self.changed = False
         self.failsafe_backups = failsafe_backups
@@ -130,10 +130,9 @@ class Config(collections.MutableMapping):
 
     def get_option(self, keyname):
         try:
-            value = self.config[keyname]
+            return self.get_by_path([keyname])
         except KeyError:
-            value = None
-        return value
+            return self.default
 
     def get_suboption(self, grouping, groupname, keyname):
         try:

--- a/hangupsbot/config.py
+++ b/hangupsbot/config.py
@@ -188,10 +188,7 @@ class Config(collections.MutableMapping):
         return _exists
 
     def __getitem__(self, key):
-        try:
-            return self.config[key]
-        except KeyError:
-            return self.default
+        return self.get_option(key)
 
     def __setitem__(self, key, value):
         self.config[key] = value

--- a/hangupsbot/config.py
+++ b/hangupsbot/config.py
@@ -148,9 +148,7 @@ class Config(collections.MutableMapping):
         logger.info("%s write %s", self.filename, interval)
 
     def flush(self):
-        if self._timer_save and self._timer_save.is_alive():
-            logger.info("flushing {}".format(self.filename))
-            self._timer_save.cancel()
+        logger.info("flushing %s", self.filename)
         self.save(delay=False)
 
     def get_by_path(self, keys_list):

--- a/hangupsbot/config.py
+++ b/hangupsbot/config.py
@@ -1,5 +1,13 @@
-import collections, datetime, functools, json, glob, logging, os, shutil, sys, time
 import asyncio
+import collections
+from datetime import datetime
+import functools
+import json
+import glob
+import logging
+import os
+import shutil
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -49,9 +57,9 @@ class Config(collections.MutableMapping):
             except IOError:
                 logger.warning('Failed to remove %s, check permissions', path)
 
-        backup_file = self.filename + "." + datetime.datetime.now().strftime("%Y%m%d%H%M%S") + ".bak"
+        backup_file = "%s.%s.bak" % (self.filename,
+                                     datetime.now().strftime("%Y%m%d%H%M%S"))
         shutil.copy2(self.filename, backup_file)
-
         return True
 
     def _recover_from_failsafe(self):

--- a/hangupsbot/config.py
+++ b/hangupsbot/config.py
@@ -230,6 +230,19 @@ class Config(collections.MutableMapping):
             elif isinstance(value, list):
                 defaults[key].extend(value)
 
+    def validate(self, source, path=None):
+        if path is None:
+            path = []
+        for key, value in source.items():
+            if not self.exists(path + [key]):
+                self.set_by_path(path + [key], value)
+
+            elif not isinstance(self.get_by_path(path + [key]), type(value)):
+                self.set_by_path(path + [key], value)
+
+            elif isinstance(value, dict) and len(value):
+                self.validate(value, path + [key])
+
     def __getitem__(self, key):
         return self.get_option(key)
 

--- a/hangupsbot/config.py
+++ b/hangupsbot/config.py
@@ -192,16 +192,14 @@ class Config(collections.MutableMapping):
         except KeyError:
             return self.get_option(keyname)
 
-    def exists(self, keys_list):
-        _exists = True
+    def exists(self, keys_list, fallback=False):
 
         try:
-            if self.get_by_path(keys_list) is None:
-                _exists = False
+            self.get_by_path(keys_list, fallback)
+            return True
         except (KeyError, TypeError):
-            _exists = False
+            return False
 
-        return _exists
     def ensure_path(self, path, base=None):
         if base is None:
             base = self.config

--- a/hangupsbot/config.py
+++ b/hangupsbot/config.py
@@ -91,7 +91,11 @@ class Config(collections.MutableMapping):
             logger.info("%s read", self.filename)
 
         except IOError:
-            self.config = {}
+            if not os.path.isfile(self.filename):
+                self.config = {}
+                self.save(delay=False)
+                return
+            raise
 
         except ValueError:
             if self.failsafe_backups and self._recover_from_failsafe():

--- a/hangupsbot/config.py
+++ b/hangupsbot/config.py
@@ -15,8 +15,8 @@ logger = logging.getLogger(__name__)
 
 class Config(collections.MutableMapping):
     """Configuration JSON storage class"""
-    def __init__(self, filename, default=None, failsafe_backups=0, save_delay=0):
-        self.filename = filename
+    def __init__(self, path, default=None, failsafe_backups=0, save_delay=0):
+        self.filename = path
         self.default = default
         self.config = {}
         self.defaults = {}


### PR DESCRIPTION
The Config Class can now store defaults in background that do not need to be stored bulk in the users ``config.json``.

``.get_by_path``, ``.get_option``, ``.get_suboption`` and direct accessing will query defaults on ``KeyError``/``ValueErrors``.

``.set_by_path`` and ``.pop_by_path`` will still access the real ``config.json`` data.
With the arg ``fallback`` in ``.get_by_path`` and also in ``.exists``, one can toggle the fallback to defaults.

Other changes:

- the check for a change in the config is now on live data, ``.force_taint()`` is no more needed. f1a5ae5

-  create the path the user wants to store a value in, this can be toggled in ``.set_by_path`` with the argument``create_path``.

- use the configured default, in some cases just ``None`` was returned and overall the default was hardcoded to ``None``, even though an  argument on init existed. d2715fc

- propper check for an existing path, ``None`` as value resulted in an non existing path

- propper Exception handling, especially ``IOError`` killing the config bbb006a

- (plugins can) validate their config parts with ``.validate`` 30eaa9e

- use ``asyncio`` to schedule a delayed dump 81eacc3