### PR TITLE
Limit number of asyncio worker threads, resolves #866

### DIFF
--- a/hangupsbot/hangupsbot.py
+++ b/hangupsbot/hangupsbot.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import appdirs, argparse, asyncio, gettext, logging, logging.config, os, shutil, signal, sys, time
+from concurrent.futures import ThreadPoolExecutor
 
 import hangups
 
@@ -147,6 +148,8 @@ class HangupsBot(object):
         if cookies:
             # Start asyncio event loop
             loop = asyncio.get_event_loop()
+            threads = self.get_config_option("max_threads") or 5
+            loop.set_default_executor(ThreadPoolExecutor(max_workers=threads))
 
             # initialise pluggable framework
             hooks.load(self)


### PR DESCRIPTION
This patch prevents excessive thread spawning by limiting the number of created worker threads for HTTP requests. The default limit is 5 worker threads, but the number is configurable via a new "max_threads" setting.

Limiting the number of worker threads is necessary to prevent the system from running out of file handles when more than one bot is running at the same time. If not changed explicitly, the default worker thread limit is system-specific (depends on the number of CPUs) and can be as high as 60 threads per bot on a 12-core CPU.

The patch resolves issue #866.