### PR TITLE
Prevent Slack from printing bot messages

### DIFF
--- a/hangupsbot/plugins/slackrtm.py
+++ b/hangupsbot/plugins/slackrtm.py
@@ -1196,6 +1196,8 @@ class SlackRTM(object):
 
     @asyncio.coroutine
     def handle_ho_message(self, event):
+        if self.bot._user_list.get_user(event.user_id).is_self:
+            return
         if "_slackrtm_no_repeat" in dir(event) and event._slackrtm_no_repeat:
             return
 
@@ -1208,7 +1210,10 @@ class SlackRTM(object):
             if sync.hotag:
                 fullname = '%s (%s)' % (fullname, sync.hotag)
             try:
-                photo_url = "http:"+self.bot._user_list.get_user(event.user_id).photo_url
+                if self.bot._user_list.get_user(event.user_id).photo_url is None:
+                    photo_url = ''
+                else:
+                    photo_url = "http:" + self.bot._user_list.get_user(event.user_id).photo_url
             except Exception as e:
                 logger.exception('error while getting user from bot: %s', e)
                 photo_url = ''


### PR DESCRIPTION
SlackRTM, upon receiving a Slack message, prints it out in Hangouts. It then sees that a new message is in Hangouts and sends it back to Slack. It appears this is not happening in the reverse because Slack isn't sending us our message back as a new message however hangups does. This change does have a side effect of not sending any of the bot text printed in Hangouts over to Slack, however, this makes Slack useable and it is worth it to me. 

Also, since my bot does not have a photo, the plugin is logging exceptions frequently. This is not an exceptional state and a user not having a photo_url should be handled prior to an exception.

Fixes https://github.com/hangoutsbot/hangoutsbot/issues/887