### PR TITLE
[plugins.tldr] dump the memory after changing it

### DIFF
--- a/hangupsbot/plugins/tldr.py
+++ b/hangupsbot/plugins/tldr.py
@@ -163,10 +163,12 @@ def tldr_base(bot, conv_id, parameters):
                 popped_tldr = conv_tldr.pop(sorted_keys[key_index])
                 for conv in conv_id_list:
                     bot.memory.set_by_path(['tldr', conv], conv_tldr)
+                bot.memory.save()
                 message = _('TL;DR #{} removed - "{}"').format(parameters[1], popped_tldr)
         elif len(parameters) == 2 and parameters[1].lower() == "all":
             for conv in conv_id_list:
                 bot.memory.set_by_path(['tldr', conv], {})
+            bot.memory.save()
             message = _("All TL;DRs cleared.")
         else:
             message = _("Nothing specified to clear.")
@@ -185,6 +187,7 @@ def tldr_base(bot, conv_id, parameters):
                 conv_tldr[sorted_keys[key_index]] = tldr
                 for conv in conv_id_list:
                     bot.memory.set_by_path(['tldr', conv], conv_tldr)
+                bot.memory.save()
                 message = _('TL;DR #{} edited - "{}" -> "{}"').format(parameters[1], edited_tldr, tldr)
         else:
             message = _('Unknown Command at "tldr edit."')
@@ -198,11 +201,10 @@ def tldr_base(bot, conv_id, parameters):
             conv_tldr[str(time.time())] = tldr
             for conv in conv_id_list:
                 bot.memory.set_by_path(['tldr', conv], conv_tldr)
+            bot.memory.save()
             message = _('<em>{}</em> added to TL;DR. Count: {}').format(tldr, len(conv_tldr))
 
             return message, display
-
-    bot.memory.save()
 
 
 def _time_ago(timestamp):


### PR DESCRIPTION
This PR addresses issues of missing tldr entrys. Changes made to a tldr did not persist.

### Steps to reproduce:
```
/bot tldr NEW ENTRY
-> new entry added
/bot tldr
-> our NEW ENTRY
# wait for `config['memory-save_delay']` - default is 1 - seconds
/bot reload
/bot tldr
-> empty
```

### Fixes:
 - The call to dump the memory to file was not reachable. https://github.com/hangoutsbot/hangoutsbot/pull/890/commits/e89a28735358c0469e2eddf7d2cf5732956dcbdc