### PR TITLE
[v3] retry coro_send_message if it fails

### DIFF
--- a/hangupsbot/hangupsbot.py
+++ b/hangupsbot/hangupsbot.py
@@ -755,12 +755,15 @@ class HangupsBot(object):
 
             _fc = FakeConversation(self, response[0])
 
-            try:
-                yield from _fc.send_message( response[1],
-                                             image_id = response[2],
-                                             context = context )
-            except hangups.NetworkError as e:
-                logger.exception("CORO_SEND_MESSAGE: error sending {}".format(response[0]))
+            for retry_count in range(3):
+                try:
+                    yield from _fc.send_message( response[1],
+                                                 image_id = response[2],
+                                                 context = context )
+                    break
+                except hangups.NetworkError as e:
+                    logger.exception("CORO_SEND_MESSAGE: error sending {}".format(response[0]))
+                    yield from asyncio.sleep(1)
 
 
     @asyncio.coroutine


### PR DESCRIPTION
Sometimes, coro_send_message fails due to an "Unexpected error". This seems to occur occasionally when sending an image. Here's an example:

2018-01-03 13:28:20 ERROR root: CORO_SEND_MESSAGE: error sending [redacted convid]
Traceback (most recent call last):
  File "hangupsbot/hangupsbot.py", line 777, in coro_send_message
    context=context )
  File "/home/bot/hangupsbot/hangupsbot/hangups_conversation.py", line 187, in send_message
    yield from self._client.send_chat_message(request)
  File "/usr/local/lib/python3.5/dist-packages/hangups/client.py", line 552, in send_chat_message
    send_chat_message_request, response)
  File "/usr/local/lib/python3.5/dist-packages/hangups/client.py", line 379, in _pb_request
    .format(status, description)
hangups.exceptions.NetworkError: Request failed with status 3: 'Unexpected error'

With this PR, a failed message will retry sending after a 1s delay, up to 2 more times. Errors are still logged.