### PR TITLE
Allow bot to parse image links from spawn command

### DIFF
--- a/hangupsbot/plugins/image/image_links.py
+++ b/hangupsbot/plugins/image/image_links.py
@@ -16,9 +16,6 @@ def _initialise(bot):
 @asyncio.coroutine
 def _watch_image_link(bot, event, command):
     # Don't handle events caused by the bot himself
-    if event.user.is_self:
-        return
-
     text = event.text
 
     if text.startswith(('https://', 'http://', '//')):

--- a/hangupsbot/plugins/image/image_links.py
+++ b/hangupsbot/plugins/image/image_links.py
@@ -15,7 +15,6 @@ def _initialise(bot):
 
 @asyncio.coroutine
 def _watch_image_link(bot, event, command):
-    # Don't handle events caused by the bot himself
     text = event.text
 
     if text.startswith(('https://', 'http://', '//')):

--- a/hangupsbot/plugins/image_links.py
+++ b/hangupsbot/plugins/image_links.py
@@ -15,7 +15,7 @@ def _initialise(bot):
 
 @asyncio.coroutine
 def _watch_image_link(bot, event, command):
-    # Don't handle events caused by the bot himself
+
     text = event.text
 
     if text.startswith(('https://', 'http://', '//')):

--- a/hangupsbot/plugins/image_links.py
+++ b/hangupsbot/plugins/image_links.py
@@ -1,0 +1,102 @@
+"""
+Identify images, upload them to google plus, post in hangouts
+"""
+import asyncio, logging, re
+
+import plugins
+
+
+logger = logging.getLogger(__name__)
+
+
+def _initialise(bot):
+    plugins.register_handler(_watch_image_link, type="message")
+
+
+@asyncio.coroutine
+def _watch_image_link(bot, event, command):
+    # Don't handle events caused by the bot himself
+    text = event.text
+
+    if text.startswith(('https://', 'http://', '//')):
+        try:
+            image_id = yield from bot.call_shared('image_validate_and_upload_single', text)
+        except KeyError:
+            logger.warning("image plugin not loaded - using in-built fallback")
+            image_id = yield from image_validate_and_upload_single(text, bot)
+
+        if image_id:
+            yield from bot.coro_send_message(event.conv.id_, None, image_id=image_id)
+
+
+"""FALLBACK CODE FOR IMAGE LINK VALIDATION AND UPLOAD
+* CODE IS DEPRECATED - DO NOT CHANGE OR ALTER
+* CODE MAY BE REMOVED AT ANY TIME
+* FOR FUTURE-PROOFING, INCLUDE [image] PLUGIN IN YOUR CONFIG.JSON
+"""
+
+import aiohttp, io, os, re
+
+def image_validate_link(image_uri, reject_googleusercontent=True):
+    """
+    validate and possibly mangle supplied image link
+    returns False, if not an image link
+            <string image uri>
+    """
+
+    if " " in image_uri:
+        """immediately reject anything with non url-encoded spaces (%20)"""
+        return False
+
+    probable_image_link = False
+
+    image_uri_lower = image_uri.lower()
+
+    if re.match("^(https?://)?([a-z0-9.]*?\.)?imgur.com/", image_uri_lower, re.IGNORECASE):
+        """imgur links can be supplied with/without protocol and extension"""
+        probable_image_link = True
+
+    elif image_uri_lower.startswith(("http://", "https://", "//")) and image_uri_lower.endswith((".png", ".gif", ".gifv", ".jpg", ".jpeg")):
+        """other image links must have protocol and end with valid extension"""
+        probable_image_link = True
+
+    if probable_image_link and reject_googleusercontent and ".googleusercontent." in image_uri_lower:
+        """reject links posted by google to prevent endless attachment loop"""
+        logger.debug("rejected link {} with googleusercontent".format(image_uri))
+        return False
+
+    if probable_image_link:
+
+        """special handler for imgur links"""
+        if "imgur.com" in image_uri:
+            if not image_uri.endswith((".jpg", ".gif", "gifv", "webm", "png")):
+                image_uri = image_uri + ".gif"
+            image_uri = "https://i.imgur.com/" + os.path.basename(image_uri)
+
+            """imgur wraps animations in player, force the actual image resource"""
+            image_uri = image_uri.replace(".webm",".gif")
+            image_uri = image_uri.replace(".gifv",".gif")
+
+        logger.debug('{} seems to be a valid image link'.format(image_uri))
+
+        return image_uri
+
+    return False
+
+@asyncio.coroutine
+def image_upload_single(image_uri, bot):
+    logger.info("getting {}".format(image_uri))
+    filename = os.path.basename(image_uri)
+    r = yield from aiohttp.request('get', image_uri)
+    raw = yield from r.read()
+    image_data = io.BytesIO(raw)
+    image_id = yield from bot._client.upload_image(image_data, filename=filename)
+    return image_id
+
+@asyncio.coroutine
+def image_validate_and_upload_single(text, bot, reject_googleusercontent=True):
+    image_id = False
+    image_link = image_validate_link(text, reject_googleusercontent=reject_googleusercontent)
+    if image_link:
+        image_id = yield from image_upload_single(image_link, bot)
+    return image_id

--- a/hangupsbot/plugins/spawn.py
+++ b/hangupsbot/plugins/spawn.py
@@ -177,3 +177,16 @@ def _spawn(bot, event, *args):
             event.user.id_.chat_id, event.conv_id, stderr_str)
     if len(stdout_str) > 0:
         yield from bot.coro_send_message(event.conv_id, stdout_str)
+
+        text = stdout_str
+
+        if text.startswith(('https://', 'http://', '//')):
+            try:
+                image_id = yield from bot.call_shared('image_validate_and_upload_single', text)
+            except KeyError:
+                logger.warning("image plugin not loaded - using in-built fallback")
+                image_id = yield from image_validate_and_upload_single(text, bot)
+
+            if image_id:
+                yield from bot.coro_send_message(event.conv.id_, None, image_id=image_id)
+


### PR DESCRIPTION
Since spawn only reads stdout the bot is otherwise unable to parse image links that a spawn command returns.