### PR TITLE
Add custom plugin finalisation hook

### DIFF
--- a/hangupsbot/plugins/__init__.py
+++ b/hangupsbot/plugins/__init__.py
@@ -504,6 +504,19 @@ def unload(bot, module_path):
         plugin = tracking.list[module_path]
         loop = asyncio.get_event_loop()
 
+        # Look for an optional function finali[sz]e, akin to initiali[sz]e.
+        public_functions = [o for o in getmembers(sys.modules[module_path], isfunction)]
+        try:
+            for function_name, the_function in public_functions:
+                if function_name in ("_finalise", "_finalize"):
+                    argc = len(inspect.signature(the_function).parameters)
+                    if argc == 0:
+                        the_function()
+                    elif argc == 1:
+                        the_function(bot)
+        except Exception as e:
+            logger.exception("EXCEPTION during plugin deinit: {}".format(module_path))
+
         if len(plugin["threads"]) == 0:
             all_commands = plugin["commands"]["all"]
             for command_name in all_commands:

--- a/hangupsbot/plugins/_chatbridge/chatbridge_slackrtm/__init__.py
+++ b/hangupsbot/plugins/_chatbridge/chatbridge_slackrtm/__init__.py
@@ -13,9 +13,14 @@ def _initialise(bot):
     root = bot.get_config_option("slackrtm") or {}
     Base.bot = bot
     for team, config in root.get("teams", {}).items():
-        Base.add_slack(team, Slack(team, config["token"]))
+        Base.add_slack(Slack(team, config["token"]))
     for sync in root.get("syncs", []):
         Base.add_bridge(BridgeInstance(bot, "slackrtm", sync))
     for slack in Base.slacks.values():
-        plugins.start_asyncio_task(slack.loop())
+        slack.start()
     plugins.register_handler(on_membership_change, type="membership")
+
+def _finalise(bot):
+    for slack in list(Base.slacks.values()):
+        Base.remove_slack(slack)
+    Base.bot = None


### PR DESCRIPTION
This allows plugins to define a top-level function `_finalise([bot])` method, similar to `_initialise`, which will be called as the first step in unloading the plugin.

Updates to telesync and SlackRTM are included, which use the finalisation call to disconnect their bridges cleanly.  Whilst the unload process cancels outstanding async tasks, both of these plugins create their own background tasks (either directly or from a third-party library) which are not tracked by the plugins module.  This causes messages to duplicate after a reload as multiple receivers are connected.