### PR TITLE
Fixed Inappropriate Logical Expression

### DIFF
--- a/hangupsbot/plugins/__init__.py
+++ b/hangupsbot/plugins/__init__.py
@@ -455,7 +455,7 @@ def load(bot, module_path, module_name=None):
         if available_commands is False:
             # implicit init, legacy support: assume all candidate_commands are user-available
             register_user_command([function_name for function_name, function in candidate_commands])
-        elif available_commands is []:
+        elif available_commands == []:
             # explicit init, no user-available commands
             pass
         else:


### PR DESCRIPTION
# Details

While triaging your project, our bug-fixing tool generated the following message(s)-

> In file: [__init__.py, method: load](https://github.com/hangoutsbot/hangoutsbot/blob/master/hangupsbot/plugins/__init__.py#L458), a logical expression uses the identity operator. A new object is created inside the identity check operation and then used for matching identity. Since this is a distinct, new object, it will not match with anything else. As a result, the identity check will have a logical short circuit and the program may have unintended behavior. iCR suggested that the logical operation should be reviewed for correctness.

In this specific case, the line 458 of the file [__init__.py](https://github.com/hangoutsbot/hangoutsbot/blob/master/hangupsbot/plugins/__init__.py#L458) is as follows:

```python
elif available_commands is []:
```

In python, the `is` operator checks for identity, not equality. This means that the `is` operator checks whether the two operands refer to the same object or not. In this case, `[]` is an empty list. However, the `[]` is a new object and is not the same as the `available_commands` variable being compared with. In the mentioned case, the `is` operator will always evaluate to False. We can test this scenerio by running the following code in python:

```python
a = []
print(a is []) # This will print False
print(a == []) # This will print True
```
Here, the `is` operator evaluates the expression to return `False`. However, it should have returned `True` in this case.

# Changes

- To ensure logical correctness, in the line 458 the `is` operator is replaced with `==` operator.

```python
elif available_commands == []:
```

Suggestions related to these changes are welcomed. 


# CLA Requirements

This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.

All contributed commits are already automatically signed off.

The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).

[Git Commit SignOff documentation](https://developercertificate.org/)


# Sponsorship and Support

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.